### PR TITLE
Experiment: Lexer with string slices and absolutely no string allocation/copy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(if_while_or_patterns)]
 #![feature(bind_by_move_pattern_guards)]
 #![feature(const_str_as_bytes)]
+#![feature(result_map_or_else)]
 
 use failure::{Error, Fail, ResultExt};
 use memmap::Mmap;
@@ -84,7 +85,7 @@ fn run_compiler(cmd: &CliCommand) -> Result<(), Error> {
                 .context(CliError::Ascii { path: path.clone() })?;
 
             let strtab = strtab::StringTable::new();
-            let lexer = lexer::Lexer::new(ascii_file.iter(), &strtab);
+            let lexer = lexer::Lexer::new(ascii_file.scanner(), &strtab);
 
             itertools::process_results(lexer, |valid_tokens| {
                 let mut stdout = io::stdout();

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,9 +122,9 @@ fn print_error(writer: &mut dyn io::Write, err: &Error) -> Result<(), Error> {
     Ok(())
 }
 
-fn run_lexer_test<L, O>(lexer: L, out: &mut O) -> Result<(), Error>
+fn run_lexer_test<'s, L, O>(lexer: L, out: &mut O) -> Result<(), Error>
 where
-    L: Iterator<Item = TokenKind>,
+    L: Iterator<Item = TokenKind<'s>>,
     O: io::Write,
 {
     let token_datas = lexer.filter(|token_data| match token_data {

--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -8,7 +8,7 @@
 
 use std::{cell::UnsafeCell, collections::HashSet, rc::Rc};
 
-pub type Symbol = Rc<str>;
+pub type Symbol<'s> = &'s str;
 
 #[derive(Debug)]
 pub struct StringTable {
@@ -22,13 +22,8 @@ impl StringTable {
         }
     }
 
-    pub fn intern(&self, value: &str) -> Symbol {
-        // Entries is private, and this is the only place where it is mutated
-        let entries = unsafe { &mut *self.entries.get() };
-        if !entries.contains(value) {
-            entries.insert(value.into());
-        }
-        Rc::clone(entries.get(value).unwrap())
+    pub fn intern<'s>(&self, value: &'s str) -> Symbol<'s> {
+        value
     }
 }
 


### PR DESCRIPTION
The lexer in this branch works by looking at string slices instead of iterating over characters, thus saving some allocation. For further testing the strtab here is a stub that just returns the very same `&str`, because I wanted to get rid of any copy. Thus, all strings in the token stream (except comments) are actually references into the `Mmap`.

My approach is based on a "Frame API", where a frame is a portion of the input stream that we are currently *looking at*; and a set of functions to (conditionally) extend and finalize a given frame.

The performance impact is nonexistent for the *holyidentifier* test: 
```
 $ perf stat target/release/comprakt  --lextest ../../IPDSnelting/mjtest-tests/lexer/holyidentifier.mj > /dev/null

 Performance counter stats for 'target/release/comprakt --lextest ../../IPDSnelting/mjtest-tests/lexer/holyidentifier.mj':

        289.778556      task-clock (msec)         #    0.896 CPUs utilized
                80      context-switches          #    0.276 K/sec
                 3      cpu-migrations            #    0.010 K/sec
             5,946      page-faults               #    0.021 M/sec
       924,356,555      cycles                    #    3.190 GHz                      (83.22%)
       236,365,751      stalled-cycles-frontend   #   25.57% frontend cycles idle     (83.49%)
        86,733,737      stalled-cycles-backend    #    9.38% backend cycles idle      (66.42%)
     2,105,200,828      instructions              #    2.28  insn per cycle
                                                  #    0.11  stalled cycles per insn  (83.03%)
       424,070,446      branches                  # 1463.429 M/sec                    (83.88%)
         2,188,197      branch-misses             #    0.52% of all branches          (83.00%)

       0.323576051 seconds time elapsed

       0.257247000 seconds user
       0.032405000 seconds sys

```

From a SW-engineering perspective, this is a two-sided sword. On the one hand I got rid of most of the `unwraps`, (and can also get rid of the rest, I think). On the other hand, the Frame API requires a lot of str- and index-fiddling internally (though I think I get rid of some of that), which is more error-prone than a simple char iterator.

Haven't updated the test, do not compile.