### PR TITLE
repair broken asciifile test: `file_starting_with_newline`

### DIFF
--- a/asciifile/src/position.rs
+++ b/asciifile/src/position.rs
@@ -424,18 +424,28 @@ mod tests {
     fn file_starting_with_newline() {
         let input = b"\none\ntwo three\nfour\n\n";
         let file = AsciiFile::new(input).unwrap();
+        let start = Position::at_file_start(&file).unwrap();
+        let end = file.iter().last().unwrap();
+        let span = Span::new(start, end);
 
-        let actual = file
+        let actual = span
             .lines()
-            .map(|line| (line.start_position().line(), line.as_str().to_string()))
+            .enumerate()
+            .map(|(real_row, line)| {
+                (
+                    real_row + 1,
+                    line.start_position().line_number(),
+                    line.as_str().to_string(),
+                )
+            })
             .collect::<Vec<_>>();
 
-        let expected: Vec<(char, String)> = vec![
-            (1, "\n".to_string()),
-            (2, "one\n".to_string()),
-            (3, "two three\n".to_string()),
-            (4, "four\n".to_string()),
-            (5, "\n".to_string()),
+        let expected: Vec<(usize, usize, String)> = vec![
+            (1, 2, "\n".to_string()),
+            (2, 2, "one\n".to_string()),
+            (3, 3, "two three\n".to_string()),
+            (4, 4, "four\n".to_string()),
+            (5, 6, "\n".to_string()),
         ];
 
         assert_eq!(expected, actual);

--- a/asciifile/src/position.rs
+++ b/asciifile/src/position.rs
@@ -452,6 +452,38 @@ mod tests {
     }
 
     #[test]
+    fn file_starting_with_two_newlines() {
+        let input = b"\n\none\ntwo three\nfour\n\n";
+        let file = AsciiFile::new(input).unwrap();
+        let start = Position::at_file_start(&file).unwrap();
+        let end = file.iter().last().unwrap();
+        let span = Span::new(start, end);
+
+        let actual = span
+            .lines()
+            .enumerate()
+            .map(|(real_row, line)| {
+                (
+                    real_row + 1,
+                    line.start_position().line_number(),
+                    line.as_str().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let expected: Vec<(usize, usize, String)> = vec![
+            (1, 2, "\n".to_string()),
+            (2, 3, "\n".to_string()),
+            (3, 3, "one\n".to_string()),
+            (4, 4, "two three\n".to_string()),
+            (5, 5, "four\n".to_string()),
+            (6, 7, "\n".to_string()),
+        ];
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn all_indexing_works() {
         file_index_roundtrip(b"one\ntwo three\nfour\n\n");
         file_index_roundtrip(b"a");


### PR DESCRIPTION
merge this before https://github.com/comprakt/comprakt/pull/59

pull #59  is the precise reason why we didn't notice the tests that were fixed in this PR didn't even compile