### PR TITLE
Resolve AST ambiguities

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -38,9 +38,8 @@ IfStatement                         if \( Expression \) Statement (else Statemen
 ExpressionStatement                 Expression ;                                                           $ Self.out = ast::Stmt::Expression(Expression.out)
 ReturnStatement                     return Expression? ;                                                   $ Self.out = ast::Stmt::Return(Some(Expression.out) | None)
 
-Expression                          LogicalOrExpression (= LogicalOrExpression)*                           $ Self.out = ast::Expr::Assignment(LogicalOrExpression_1, LogicalOrExpression_2.all_outs)
-
 // BEGIN precedence climbing
+Expression                          LogicalOrExpression (= Expression)?                                    $ Self.out = ast::Expr::Binary(<binop>, Lhs, Rhs)
 LogicalOrExpression                 (LogicalAndExpression \|\|)? LogicalAndExpression                      $ <analog>
 LogicalAndExpression                (EqualityExpression &&)? EqualityExpression                            $ <analog>
 EqualityExpression                  (RelationalExpression (== | !=))? RelationalExpression                 $ <analog>

--- a/grammar.md
+++ b/grammar.md
@@ -41,12 +41,12 @@ ReturnStatement                     return Expression? ;                        
 Expression                          LogicalOrExpression (= LogicalOrExpression)*                           $ Self.out = ast::Expr::Assignment(LogicalOrExpression_1, LogicalOrExpression_2.all_outs)
 
 // BEGIN precedence climbing
-LogicalOrExpression                 LogicalAndExpression (\|\| LogicalAndExpression)*                      $ Self.out = ast::Expr::Binary(<binop>, Lhs, Rhs)
-LogicalAndExpression                EqualityExpression (&& EqualityExpression)*                            $ <analog>
-EqualityExpression                  RelationalExpression ( (== | !=) RelationalExpression)*                $ <analog>
-RelationalExpression                AddititveExpression ( (< | <= | > | >=) AdditiveExpression )*          $ <analog>
-AdditiveExpression                  MultiplicativeExpression ( (+|-) MultiplicativeExpression )*           $ <analog>
-MultiplicativeExpression            UnaryExpression ( (\*|/|%) UnaryExpression)*                           $ <analog>
+LogicalOrExpression                 (LogicalAndExpression \|\|)? LogicalAndExpression                      $ <analog>
+LogicalAndExpression                (EqualityExpression &&)? EqualityExpression                            $ <analog>
+EqualityExpression                  (RelationalExpression (== | !=))? RelationalExpression                 $ <analog>
+RelationalExpression                (AddititveExpression (< | <= | > | >=))? AdditiveExpression            $ <analog>
+AdditiveExpression                  (MultiplicativeExpression (+|-))? MultiplicativeExpression             $ <analog>
+MultiplicativeExpression            (UnaryExpression (\*|/|%))? UnaryExpression                            $ <analog>
 // END precedence climbing
 
 UnaryExpression                     (! | -)* PostfixExpression                                             $ Self.out = ast::Expr::Unary(UnaryOp::from("!|"-"), PostfixExpression.out)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -146,8 +146,8 @@ pub enum Expr<'t> {
         Box<Spanned<'t, Expr<'t>>>,
         Box<Spanned<'t, Expr<'t>>>,
     ),
-    Unary(Vec<UnaryOp>, Box<Spanned<'t, Expr<'t>>>),
-    Postfix(Box<Spanned<'t, Expr<'t>>>, Vec<Spanned<'t, PostfixOp<'t>>>),
+    Unary(UnaryOp, Box<Spanned<'t, Expr<'t>>>),
+    Postfix(Box<Spanned<'t, Expr<'t>>>, Spanned<'t, PostfixOp<'t>>),
     // The old primary expressions
     Null,
     Boolean(bool),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -124,8 +124,12 @@ pub enum Stmt<'t> {
 /// * `Assignment`: an assignment expression
 /// * `Binary`: one of the binary operations defined in `BinaryOp`
 /// * `Unary`: one of the unary operations defined in `UnaryOp`
-/// * `Postfix`: a primary expression with arbitrary many postfix operations
-/// defined in `PostfixOp`
+/// * `MethodInvocation`: a method invocation on a primary expression:
+/// `foo.method()`
+/// * `FieldAccess`: a field access on a primary expression:
+/// `foo.bar`
+/// * `ArrayAccess`: an array access on a primary expression:
+/// `foo[42]`
 /// The primary expression from the original grammar are also part of this,
 /// since the distinction is only required for correct postfix-op parsing. These
 /// are:
@@ -146,13 +150,22 @@ pub enum Expr<'t> {
         Box<Spanned<'t, Expr<'t>>>,
     ),
     Unary(UnaryOp, Box<Spanned<'t, Expr<'t>>>),
-    Postfix(Box<Spanned<'t, Expr<'t>>>, Spanned<'t, PostfixOp<'t>>),
+
+    // Postfix ops
+    MethodInvocation(
+        Box<Spanned<'t, Expr<'t>>>,
+        Symbol,
+        Spanned<'t, ArgumentList<'t>>,
+    ),
+    FieldAccess(Box<Spanned<'t, Expr<'t>>>, Symbol),
+    ArrayAccess(Box<Spanned<'t, Expr<'t>>>, Box<Spanned<'t, Expr<'t>>>),
+
     // The old primary expressions
     Null,
     Boolean(bool),
     Int(Symbol), // TODO Should be String?
     Var(Symbol),
-    MethodInvocation(Symbol, Spanned<'t, ArgumentList<'t>>),
+    ThisMethodInvocation(Symbol, Spanned<'t, ArgumentList<'t>>),
     This,
     NewObject(Symbol),
     NewArray(BasicType, Box<Spanned<'t, Expr<'t>>>, u64),
@@ -189,18 +202,3 @@ pub enum UnaryOp {
 }
 
 pub type ArgumentList<'t> = Vec<Spanned<'t, Expr<'t>>>;
-
-/// A postfix operation is either one of
-/// * `MethodInvocation`: a method invocation on a primary expression:
-/// `foo.method()`
-/// * `FieldAccess`: a field access on a primary expression:
-/// `foo.bar`
-/// * `ArrayAccess`: an array access on a primary expression:
-/// `foo[42]`
-#[strum_discriminants(derive(Display))]
-#[derive(EnumDiscriminants, Debug, PartialEq, Eq)]
-pub enum PostfixOp<'t> {
-    MethodInvocation(Symbol, Spanned<'t, ArgumentList<'t>>),
-    FieldAccess(Symbol),
-    ArrayAccess(Box<Spanned<'t, Expr<'t>>>),
-}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -140,7 +140,6 @@ pub enum Stmt<'t> {
 #[strum_discriminants(derive(Display))]
 #[derive(EnumDiscriminants, Debug, PartialEq, Eq)]
 pub enum Expr<'t> {
-    Assignment(Box<Spanned<'t, Expr<'t>>>, Vec<Spanned<'t, Expr<'t>>>),
     Binary(
         BinaryOp,
         Box<Spanned<'t, Expr<'t>>>,
@@ -163,6 +162,8 @@ pub enum Expr<'t> {
 /// operations (`||`, `&&`) or algebraic operation (`+`, `-`, `*`, `/`, `%`).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum BinaryOp {
+    Assign,
+
     Equals,
     NotEquals,
     LessThan,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,6 @@ type Precedence = usize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Assoc {
     Left,
-    #[allow(dead_code)]
     Right,
 }
 #[rustfmt::skip]
@@ -37,6 +36,9 @@ const BINARY_OPERATORS: &[(Operator, ast::BinaryOp, Precedence, Assoc)] = &[
 
     (Operator::DoubleAmpersand,   ast::BinaryOp::LogicalAnd,    5, Assoc::Left),
     (Operator::DoublePipe,        ast::BinaryOp::LogicalOr,     6, Assoc::Left),
+
+    (Operator::Equal,             ast::BinaryOp::Assign,       10, Assoc::Right),
+
 ];
 
 #[rustfmt::skip]
@@ -522,22 +524,7 @@ where
     }
 
     fn parse_expression(&mut self) -> BoxedResult<'f, ast::Expr<'f>> {
-        spanned!(self, {
-            let lvalue = self.parse_binary_expression()?;
-
-            // Assignment expression
-            let mut rvalues = Vec::new();
-            while self.omnomnoptional(exactly(Operator::Equal))?.is_some() {
-                rvalues.push(*self.parse_binary_expression()?);
-            }
-
-            if rvalues.is_empty() {
-                return Ok(lvalue);
-            } else {
-                Ok(ast::Expr::Assignment(lvalue, rvalues))
-            }
-        })
-        .map(Box::new)
+        self.parse_binary_expression()
     }
 
     /// This uses an adapted version of Djikstras original "Shunting Yard"

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -405,29 +405,13 @@ fn do_prettyprint_expr<'a, 't>(expr: &'a crate::ast::Expr<'t>, printer: &mut Ind
             do_prettyprint(&NodeKind::from(op), printer);
             do_prettyprint_expr_parenthesized(&rhs.data, printer);
         }
-        Unary(ops, expr) => {
-            for (i, op) in ops.iter().enumerate() {
-                do_prettyprint(&NodeKind::from(op), printer);
-                if i != ops.len() - 1 {
-                    printer.print_str(&"(");
-                }
-            }
+        Unary(op, expr) => {
+            do_prettyprint(&NodeKind::from(op), printer);
             do_prettyprint_expr_parenthesized(&expr.data, printer);
-            for _ in ops.iter().skip(1) {
-                printer.print_str(&")");
-            }
         }
-        Postfix(prime, post_ops) => {
-            for _ in post_ops.iter().skip(1) {
-                printer.print_str(&"(");
-            }
+        Postfix(prime, post) => {
             do_prettyprint_expr_parenthesized(&prime.data, printer);
-            for (i, post) in post_ops.iter().enumerate() {
-                if i > 0 {
-                    printer.print_str(&")");
-                }
-                do_prettyprint(&NodeKind::from(&post.data), printer);
-            }
+            do_prettyprint(&NodeKind::from(&post.data), printer);
         }
         Null => printer.print_str(&"null"),
         Boolean(val) => printer.print(format_args!("{}", val)),

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -315,26 +315,6 @@ fn do_prettyprint(n: &NodeKind<'_, '_>, printer: &mut IndentPrinter<'_>) {
                 Neg => printer.print_str(&"-"),
             }
         }
-
-        PostfixOp(postfix_op) => {
-            use crate::ast::PostfixOp::*;
-            match postfix_op {
-                MethodInvocation(name, args) => {
-                    printer.print(format_args!(".{}(", name));
-                    print_argument_list(&args.data, printer);
-                    printer.print_str(&")");
-                }
-                FieldAccess(name) => {
-                    printer.print(format_args!(".{}", name));
-                }
-                ArrayAccess(expr) => {
-                    // no parenthesizes for array index expressions
-                    printer.print_str(&"[");
-                    do_prettyprint_expr(&expr.data, printer);
-                    printer.print_str(&"]");
-                }
-            }
-        }
     }
 }
 
@@ -395,15 +375,28 @@ fn do_prettyprint_expr<'a, 't>(expr: &'a crate::ast::Expr<'t>, printer: &mut Ind
             do_prettyprint(&NodeKind::from(op), printer);
             do_prettyprint_expr_parenthesized(&expr.data, printer);
         }
-        Postfix(prime, post) => {
-            do_prettyprint_expr_parenthesized(&prime.data, printer);
-            do_prettyprint(&NodeKind::from(&post.data), printer);
+        MethodInvocation(target_expr, name, args) => {
+            do_prettyprint_expr_parenthesized(target_expr, printer);
+            printer.print(format_args!(".{}(", name));
+            print_argument_list(&args.data, printer);
+            printer.print_str(&")");
+        }
+        FieldAccess(target_expr, name) => {
+            do_prettyprint_expr_parenthesized(target_expr, printer);
+            printer.print(format_args!(".{}", name));
+        }
+        ArrayAccess(target_expr, idx_expr) => {
+            do_prettyprint_expr_parenthesized(target_expr, printer);
+            // no parenthesizes for array index expressions
+            printer.print_str(&"[");
+            do_prettyprint_expr(&idx_expr.data, printer);
+            printer.print_str(&"]");
         }
         Null => printer.print_str(&"null"),
         Boolean(val) => printer.print(format_args!("{}", val)),
         Int(val) => printer.print(format_args!("{}", val)),
         Var(name) => printer.print(format_args!("{}", name)),
-        MethodInvocation(name, args) => {
+        ThisMethodInvocation(name, args) => {
             printer.print(format_args!("{}(", name));
             print_argument_list(&args.data, printer);
             printer.print_str(&")");

--- a/src/print/pretty.rs
+++ b/src/print/pretty.rs
@@ -290,6 +290,7 @@ fn do_prettyprint(n: &NodeKind<'_, '_>, printer: &mut IndentPrinter<'_>) {
             printer.print_str(&" ");
             use crate::ast::BinaryOp::*;
             match bin_op {
+                Assign => printer.print_str(&"="),
                 Equals => printer.print_str(&"=="),
                 NotEquals => printer.print_str(&"!="),
                 LessThan => printer.print_str(&"<"),
@@ -385,21 +386,6 @@ fn do_prettyprint_expr_parenthesized<'a, 't>(
 fn do_prettyprint_expr<'a, 't>(expr: &'a crate::ast::Expr<'t>, printer: &mut IndentPrinter<'_>) {
     use crate::ast::Expr::*;
     match expr {
-        Assignment(assignee, assignments) => {
-            // assignee: a, assignments: [b, c, d]
-            // => "a = (b = (c = d))"
-            do_prettyprint_expr_parenthesized(&assignee.data, printer);
-            for (i, assigned) in assignments.iter().enumerate() {
-                printer.print_str(&" = ");
-                if i != assignments.len() - 1 {
-                    printer.print_str(&"(");
-                }
-                do_prettyprint_expr_parenthesized(&assigned.data, printer);
-            }
-            for _ in assignments.iter().skip(1) {
-                printer.print_str(&")");
-            }
-        }
         Binary(op, lhs, rhs) => {
             do_prettyprint_expr_parenthesized(&lhs.data, printer);
             do_prettyprint(&NodeKind::from(op), printer);

--- a/src/print/structure.rs
+++ b/src/print/structure.rs
@@ -60,8 +60,6 @@ impl_astnode_struct!(discr     => 't, ast::Stmt<'t>, ast::StmtDiscriminants::fro
 impl_astnode_struct!(discr     => 't, ast::Expr<'t>, ast::ExprDiscriminants::from);
 impl_astnode_struct!(simple    => ast::BinaryOp);
 impl_astnode_struct!(simple    => ast::UnaryOp);
-#[rustfmt::skip]
-impl_astnode_struct!(discr     => 't, ast::PostfixOp<'t>, ast::PostfixOpDiscriminants::from);
 
 struct Printer<'w> {
     writer: &'w mut dyn std::io::Write,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -112,10 +112,6 @@ impl<'a, 't> NodeKind<'a, 't> {
             Expr(e) => {
                 use crate::ast::Expr::*;
                 match e {
-                    Assignment(lhs, rhs) => {
-                        ccb!(lhs.as_ref());
-                        rhs.iter().for_each(|x| ccb!(x));
-                    }
                     Binary(_, lhs, rhs) => {
                         ccb!(lhs.as_ref());
                         ccb!(rhs.as_ref());

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -121,9 +121,9 @@ impl<'a, 't> NodeKind<'a, 't> {
                         ccb!(rhs.as_ref());
                     }
                     Unary(_, expr) => ccb!(expr.as_ref()),
-                    Postfix(expr, posts) => {
+                    Postfix(expr, post) => {
                         ccb!(expr.as_ref());
-                        posts.iter().for_each(|p| ccb!(p));
+                        ccb!(post);
                     }
                     Null | Boolean(_) | Int(_) | Var(_) | This => (),
                     MethodInvocation(_, al) => al.iter().for_each(|a| ccb!(a)),


### PR DESCRIPTION
Closes #65 
- Make `Expr::Unary` recursive instead of Vec
- Same for `Postfix`
- Replace `Expr::Assignment(lvalue, rvalue)` with `Expr::Binary(BinaryOp::Assign, lvalue, rvalue)`

- Also fixes a bug in the grammer spec