### PR TITLE
Zero-copy Tokens

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -172,8 +172,8 @@ where
     C: Fn(&ast::AST<'_>, &context::Context<'_>) -> Result<(), Error>,
 {
     setup_io!(let context = path);
-    let strtab = StringTable::new();
-    let lexer = Lexer::new(&strtab, &context);
+    let mut strtab = StringTable::new();
+    let lexer = Lexer::new(&mut strtab, &context);
 
     // adapt lexer to fail on first error
     // filter whitespace and comments
@@ -208,8 +208,8 @@ where
     P: Fn(&ast::AST<'_>, &mut dyn std::io::Write) -> Result<(), Error>,
 {
     setup_io!(let context = path);
-    let strtab = StringTable::new();
-    let lexer = Lexer::new(&strtab, &context);
+    let mut strtab = StringTable::new();
+    let lexer = Lexer::new(&mut strtab, &context);
 
     // adapt lexer to fail on first error
     // filter whitespace and comments
@@ -241,8 +241,8 @@ where
 
 fn cmd_parsetest(path: &PathBuf) -> Result<(), Error> {
     setup_io!(let context = path);
-    let strtab = StringTable::new();
-    let lexer = Lexer::new(&strtab, &context);
+    let mut strtab = StringTable::new();
+    let lexer = Lexer::new(&mut strtab, &context);
 
     // adapt lexer to fail on first error
     // filter whitespace and comments
@@ -272,8 +272,8 @@ fn cmd_parsetest(path: &PathBuf) -> Result<(), Error> {
 
 fn cmd_lextest(path: &PathBuf) -> Result<(), Error> {
     setup_io!(let context = path);
-    let strtab = StringTable::new();
-    let lexer = Lexer::new(&strtab, &context);
+    let mut strtab = StringTable::new();
+    let lexer = Lexer::new(&mut strtab, &context);
 
     let mut stdout = io::stdout();
 
@@ -295,7 +295,7 @@ fn cmd_lextest(path: &PathBuf) -> Result<(), Error> {
     Ok(())
 }
 
-fn write_token<O: io::Write>(out: &mut O, token: &TokenKind) -> Result<(), Error> {
+fn write_token<O: io::Write>(out: &mut O, token: &TokenKind<'_>) -> Result<(), Error> {
     match token {
         TokenKind::Whitespace | TokenKind::Comment(_) => Ok(()),
         _ => {

--- a/compiler-lib/src/asciifile/position.rs
+++ b/compiler-lib/src/asciifile/position.rs
@@ -83,7 +83,7 @@ impl<'t> Position<'t> {
         self.byte_offset
     }
 
-    pub fn file(&self) -> &AsciiFile<'_> {
+    pub fn file(&self) -> &AsciiFile<'t> {
         self.file
     }
 

--- a/compiler-lib/src/asciifile/span.rs
+++ b/compiler-lib/src/asciifile/span.rs
@@ -83,12 +83,12 @@ impl<'f> Span<'f> {
     /// let span = Span::from_positions(&positions).unwrap();
     /// assert_eq!("abcdfegh", span.as_str());
     /// ```
-    pub fn as_str(&'f self) -> &'f str {
+    pub fn as_str(&self) -> &'f str {
         // the range is inclusive on both sides!
         unsafe { std::str::from_utf8_unchecked(self.as_bytes()) }
     }
 
-    pub fn as_bytes(&'f self) -> &'f [u8] {
+    pub fn as_bytes(&self) -> &'f [u8] {
         // the range is inclusive on both sides!
         &self.start.file().mapping[self.start.byte_offset()..=self.end.byte_offset()]
     }

--- a/compiler-lib/src/ast.rs
+++ b/compiler-lib/src/ast.rs
@@ -1,4 +1,4 @@
-use crate::{asciifile::Spanned, strtab::Symbol};
+use crate::{asciifile::Spanned, lexer::IntLit, strtab::Symbol};
 use strum_macros::EnumDiscriminants;
 
 #[strum_discriminants(derive(Display))]
@@ -162,7 +162,7 @@ pub enum Expr<'t> {
     // The old primary expressions
     Null,
     Boolean(bool),
-    Int(Symbol), // TODO Should be String?
+    Int(IntLit<'t>),
     Var(Symbol),
     ThisMethodInvocation(Symbol, Spanned<'t, ArgumentList<'t>>),
     This,

--- a/compiler-lib/src/ast.rs
+++ b/compiler-lib/src/ast.rs
@@ -19,7 +19,7 @@ pub struct Program<'t> {
 /// the members of the class.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ClassDeclaration<'t> {
-    pub name: Symbol,
+    pub name: Symbol<'t>,
     pub members: Vec<Spanned<'t, ClassMember<'t>>>,
 }
 
@@ -28,7 +28,7 @@ pub struct ClassDeclaration<'t> {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ClassMember<'t> {
     pub kind: ClassMemberKind<'t>,
-    pub name: Symbol,
+    pub name: Symbol<'t>,
 }
 
 pub type ParameterList<'t> = Vec<Spanned<'t, Parameter<'t>>>;
@@ -42,45 +42,45 @@ pub type ParameterList<'t> = Vec<Spanned<'t, Parameter<'t>>>;
 #[strum_discriminants(derive(Display))]
 #[derive(EnumDiscriminants, Debug, PartialEq, Eq, Clone)]
 pub enum ClassMemberKind<'t> {
-    Field(Spanned<'t, Type>),
+    Field(Spanned<'t, Type<'t>>),
     Method(
-        Spanned<'t, Type>,
+        Spanned<'t, Type<'t>>,
         Spanned<'t, ParameterList<'t>>,
         Spanned<'t, Block<'t>>,
     ),
-    MainMethod(Symbol, Spanned<'t, Block<'t>>),
+    MainMethod(Symbol<'t>, Spanned<'t, Block<'t>>),
 }
 
 /// This AST node represents a method parameter. A parameter consists of a
-/// `Type` and a name.
+/// `Type<'t>` and a name.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Parameter<'t> {
-    pub ty: Spanned<'t, Type>,
-    pub name: Symbol,
+    pub ty: Spanned<'t, Type<'t>>,
+    pub name: Symbol<'t>,
 }
 
-/// A `Type` is basically a `BasicType`. Optional it can be an (n-dimensional)
-/// array type.
+/// A `Type<'t>` is basically a `BasicType<'t>`. Optional it can be an
+/// (n-dimensional) array type.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Type {
-    pub basic: BasicType,
+pub struct Type<'t> {
+    pub basic: BasicType<'t>,
     /// Depth of the array type (number of `[]`) i.e. this means means `self.ty
     /// []^(self.array)`
     pub array_depth: u64,
 }
 
-/// A `BasicType` is either one of
+/// A `BasicType<'t>` is either one of
 /// * `Int`: a 32-bit integer
 /// * `Boolean`: a boolean
 /// * `Void`: a void type
 /// * `Custom`: a custom defined type
 #[strum_discriminants(derive(Display))]
 #[derive(EnumDiscriminants, Debug, PartialEq, Eq, Clone)]
-pub enum BasicType {
+pub enum BasicType<'t> {
     Int,
     Boolean,
     Void,
-    Custom(Symbol),
+    Custom(Symbol<'t>),
 }
 
 /// A `Block` in the AST is basically just a vector of statements.
@@ -113,8 +113,8 @@ pub enum Stmt<'t> {
     Expression(Box<Spanned<'t, Expr<'t>>>),
     Return(Option<Box<Spanned<'t, Expr<'t>>>>),
     LocalVariableDeclaration(
-        Spanned<'t, Type>,
-        Symbol,
+        Spanned<'t, Type<'t>>,
+        Symbol<'t>,
         Option<Box<Spanned<'t, Expr<'t>>>>,
     ),
 }
@@ -153,21 +153,21 @@ pub enum Expr<'t> {
     // Postfix ops
     MethodInvocation(
         Box<Spanned<'t, Expr<'t>>>,
-        Symbol,
+        Symbol<'t>,
         Spanned<'t, ArgumentList<'t>>,
     ),
-    FieldAccess(Box<Spanned<'t, Expr<'t>>>, Symbol),
+    FieldAccess(Box<Spanned<'t, Expr<'t>>>, Symbol<'t>),
     ArrayAccess(Box<Spanned<'t, Expr<'t>>>, Box<Spanned<'t, Expr<'t>>>),
 
     // The old primary expressions
     Null,
     Boolean(bool),
     Int(IntLit<'t>),
-    Var(Symbol),
-    ThisMethodInvocation(Symbol, Spanned<'t, ArgumentList<'t>>),
+    Var(Symbol<'t>),
+    ThisMethodInvocation(Symbol<'t>, Spanned<'t, ArgumentList<'t>>),
     This,
-    NewObject(Symbol),
-    NewArray(BasicType, Box<Spanned<'t, Expr<'t>>>, u64),
+    NewObject(Symbol<'t>),
+    NewArray(BasicType<'t>, Box<Spanned<'t, Expr<'t>>>, u64),
 }
 
 /// Binary operations like comparisons (`==`, `!=`, `<=`, ...), logical

--- a/compiler-lib/src/lexer.rs
+++ b/compiler-lib/src/lexer.rs
@@ -32,12 +32,14 @@ pub type TokenResult<'f> = Result<Token<'f>, LexicalError<'f>>;
 pub type Token<'f> = Spanned<'f, TokenKind<'f>>;
 pub type LexicalError<'f> = Spanned<'f, ErrorKind>;
 
+pub type IntLit<'f> = &'f str;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TokenKind<'f> {
     Keyword(Keyword),
     Operator(Operator),
     Identifier(Symbol),
-    IntegerLiteral(Symbol),
+    IntegerLiteral(IntLit<'f>),
     Comment(&'f str),
     Whitespace,
 }
@@ -449,7 +451,7 @@ impl<'f, 's> Lexer<'f, 's> {
         let position = self.input.next().unwrap();
         Ok(Token::new(
             position.to_single_char_span(),
-            TokenKind::IntegerLiteral(self.strtab.intern("0")),
+            TokenKind::IntegerLiteral("0"),
         ))
     }
 
@@ -473,7 +475,7 @@ impl<'f, 's> Lexer<'f, 's> {
 
         let span = self.lex_while(|position, _| matches!(position.chr(), '0'..='9'));
 
-        let kind = TokenKind::IntegerLiteral(self.strtab.intern(&span.as_str()));
+        let kind = TokenKind::IntegerLiteral(span.as_str());
 
         Ok(Token::new(span, kind))
     }
@@ -706,7 +708,7 @@ mod tests {
         let tokens = vec![
             TokenKind::Operator(Operator::Ampersand),
             TokenKind::Whitespace,
-            TokenKind::IntegerLiteral(st.intern("foo")),
+            TokenKind::IntegerLiteral("foo"),
             TokenKind::Comment("comment"),
             TokenKind::Keyword(Keyword::If),
         ];
@@ -739,7 +741,7 @@ mod tests {
     #[test]
     fn integer_literal_prefix() {
         let st = StringTable::new();
-        let o = lexer_test_with_tokens(vec![TokenKind::IntegerLiteral(st.intern("2342"))]);
+        let o = lexer_test_with_tokens(vec![TokenKind::IntegerLiteral("2342")]);
         assert_eq!(&o, "integer literal 2342\n");
     }
 }

--- a/compiler-lib/src/lexer.rs
+++ b/compiler-lib/src/lexer.rs
@@ -402,7 +402,7 @@ impl fmt::Display for Operator {
 
 pub struct Lexer<'f, 's> {
     input: PositionIterator<'f>,
-    strtab: &'s StringTable<'f>,
+    strtab: &'s mut StringTable<'f>,
     context: &'f Context<'f>,
 }
 
@@ -416,7 +416,7 @@ fn is_minijava_whitespace(c: char) -> bool {
 }
 
 impl<'f, 's> Lexer<'f, 's> {
-    pub fn new(strtab: &'s StringTable<'f>, context: &'f Context<'f>) -> Self {
+    pub fn new(strtab: &'s mut StringTable<'f>, context: &'f Context<'f>) -> Self {
         let input = context.file.iter();
 
         Self {
@@ -704,7 +704,6 @@ mod tests {
 
     #[test]
     fn no_whitespace_and_comments() {
-        let st = StringTable::new();
         let tokens = vec![
             TokenKind::Operator(Operator::Ampersand),
             TokenKind::Whitespace,
@@ -733,14 +732,13 @@ mod tests {
 
     #[test]
     fn ident_prefix() {
-        let st = StringTable::new();
+        let mut st = StringTable::new();
         let o = lexer_test_with_tokens(vec![TokenKind::Identifier(st.intern("an_identifier"))]);
         assert_eq!(&o, "identifier an_identifier\n");
     }
 
     #[test]
     fn integer_literal_prefix() {
-        let st = StringTable::new();
         let o = lexer_test_with_tokens(vec![TokenKind::IntegerLiteral("2342")]);
         assert_eq!(&o, "integer literal 2342\n");
     }

--- a/compiler-lib/src/lexer.rs
+++ b/compiler-lib/src/lexer.rs
@@ -38,7 +38,7 @@ pub type IntLit<'f> = &'f str;
 pub enum TokenKind<'f> {
     Keyword(Keyword),
     Operator(Operator),
-    Identifier(Symbol),
+    Identifier(Symbol<'f>),
     IntegerLiteral(IntLit<'f>),
     Comment(&'f str),
     Whitespace,
@@ -402,7 +402,7 @@ impl fmt::Display for Operator {
 
 pub struct Lexer<'f, 's> {
     input: PositionIterator<'f>,
-    strtab: &'s StringTable,
+    strtab: &'s StringTable<'f>,
     context: &'f Context<'f>,
 }
 
@@ -416,7 +416,7 @@ fn is_minijava_whitespace(c: char) -> bool {
 }
 
 impl<'f, 's> Lexer<'f, 's> {
-    pub fn new(strtab: &'s StringTable, context: &'f Context<'f>) -> Self {
+    pub fn new(strtab: &'s StringTable<'f>, context: &'f Context<'f>) -> Self {
         let input = context.file.iter();
 
         Self {

--- a/compiler-lib/src/parser.rs
+++ b/compiler-lib/src/parser.rs
@@ -99,8 +99,8 @@ impl<'f> From<Keyword> for Exactly<'f> {
     }
 }
 
-impl<'f> From<Symbol> for Exactly<'f> {
-    fn from(sym: Symbol) -> Self {
+impl<'f> From<Symbol<'f>> for Exactly<'f> {
+    fn from(sym: Symbol<'f>) -> Self {
         Exactly(TokenKind::Identifier(sym))
     }
 }
@@ -145,10 +145,10 @@ impl<'f> ExpectedToken<'f> for UnaryOp {
 }
 
 impl<'f> ExpectedToken<'f> for Identifier {
-    type Yields = Symbol;
+    type Yields = Symbol<'f>;
     fn matching(&self, token: &TokenKind<'f>) -> Option<Self::Yields> {
         match token {
-            TokenKind::Identifier(ident) => Some(ident.clone()),
+            TokenKind::Identifier(ident) => Some(*ident),
             _ => None,
         }
     }
@@ -386,7 +386,7 @@ where
         })
     }
 
-    fn parse_type(&mut self) -> ParserResult<'f, ast::Type> {
+    fn parse_type(&mut self) -> ParserResult<'f, ast::Type<'f>> {
         spanned!(self, {
             let basic = self.parse_basic_type()?;
 
@@ -403,7 +403,7 @@ where
         })
     }
 
-    fn parse_basic_type(&mut self) -> SyntaxResult<'f, ast::BasicType> {
+    fn parse_basic_type(&mut self) -> SyntaxResult<'f, ast::BasicType<'f>> {
         if self.omnomnoptional(exactly(Keyword::Int))?.is_some() {
             Ok(ast::BasicType::Int)
         } else if self.omnomnoptional(exactly(Keyword::Boolean))?.is_some() {

--- a/compiler-lib/src/parser.rs
+++ b/compiler-lib/src/parser.rs
@@ -4,7 +4,7 @@ use crate::{
         Span, Spanned,
     },
     ast,
-    lexer::{Keyword, Operator, Token, TokenKind},
+    lexer::{IntLit, Keyword, Operator, Token, TokenKind},
     spantracker::*,
     strtab::Symbol,
 };
@@ -155,10 +155,10 @@ impl<'f> ExpectedToken<'f> for Identifier {
 }
 
 impl<'f> ExpectedToken<'f> for IntegerLiteral {
-    type Yields = Symbol;
+    type Yields = IntLit<'f>;
     fn matching(&self, token: &TokenKind<'f>) -> Option<Self::Yields> {
         match token {
-            TokenKind::IntegerLiteral(lit) => Some(lit.clone()),
+            TokenKind::IntegerLiteral(lit) => Some(lit),
             _ => None,
         }
     }
@@ -956,13 +956,13 @@ mod tests {
                     match lhs.data {
                         Expr::Binary(op, lhs, rhs) => {
                             assert_eq!(op, Add);
-                            assert_eq!(lhs.data, Expr::Int(Symbol::from("3")));
+                            assert_eq!(lhs.data, Expr::Int("3"));
                             // rhs = 4 * 7
                             match rhs.data {
                                 Expr::Binary(op, lhs, rhs) => {
                                     assert_eq!(op, Mul);
-                                    assert_eq!(lhs.data, Expr::Int(Symbol::from("4")));
-                                    assert_eq!(rhs.data, Expr::Int(Symbol::from("7")));
+                                    assert_eq!(lhs.data, Expr::Int("4"));
+                                    assert_eq!(rhs.data, Expr::Int("7"));
                                 }
                                 expr => panic!("not a binary expr: {:#?}", expr),
                             }
@@ -977,12 +977,12 @@ mod tests {
                             match lhs.data {
                                 Expr::Binary(op, lhs, rhs) => {
                                     assert_eq!(op, Div);
-                                    assert_eq!(lhs.data, Expr::Int(Symbol::from("9")));
-                                    assert_eq!(rhs.data, Expr::Int(Symbol::from("7")));
+                                    assert_eq!(lhs.data, Expr::Int("9"));
+                                    assert_eq!(rhs.data, Expr::Int("7"));
                                 }
                                 expr => panic!("not a binary expr: {:#?}", expr),
                             }
-                            assert_eq!(rhs.data, Expr::Int(Symbol::from("42")));
+                            assert_eq!(rhs.data, Expr::Int("42"));
                         }
                         expr => panic!("not a binary expr: {:#?}", expr),
                     }

--- a/compiler-lib/src/print/lextest.rs
+++ b/compiler-lib/src/print/lextest.rs
@@ -5,11 +5,11 @@ use std::fmt;
 ///! messages.
 
 pub struct Output<'token> {
-    token: &'token TokenKind,
+    token: &'token TokenKind<'token>,
 }
 
 impl<'token> Output<'token> {
-    pub fn new(token: &'token TokenKind) -> Self {
+    pub fn new(token: &'token TokenKind<'token>) -> Self {
         Self { token }
     }
 }

--- a/compiler-lib/src/print/structure.rs
+++ b/compiler-lib/src/print/structure.rs
@@ -47,8 +47,8 @@ impl AstNode for ast::ClassMember<'_> {
 impl_astnode_struct!(discr     => 't, ast::ClassMemberKind<'t>, ast::ClassMemberKindDiscriminants::from);
 impl_astnode_struct!(lt_struct => 't, ast::Parameter<'t>);
 impl_astnode_struct!(lt_struct => 't, ast::ParameterList<'t>);
-impl_astnode_struct!(simple    => ast::Type);
-impl AstNode for ast::BasicType {
+impl_astnode_struct!(lt_struct => 't, ast::Type<'t>);
+impl AstNode for ast::BasicType<'_> {
     fn as_ast_node(&self, printer: &mut Printer<'_>) -> std::io::Result<()> {
         let type_name = unsafe { (std::intrinsics::type_name::<Self>()) };
         let discr = ast::BasicTypeDiscriminants::from(self);

--- a/compiler-lib/src/strtab.rs
+++ b/compiler-lib/src/strtab.rs
@@ -63,6 +63,14 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    macro_rules! assert_eq_sym {
+        ($a:expr, $b:expr) => {
+            assert_eq!($a, $b);
+            // don't trust that eq impl is based on pointer comparison
+            assert_eq!($a.as_raw(), $b.as_raw());
+        };
+    }
+
     #[test]
     fn no_duplication() {
         let mut strtab = StringTable::new();
@@ -71,31 +79,15 @@ mod tests {
         let b = strtab.intern("foo");
         let c = strtab.intern("foo");
         assert_eq!(1, strtab.entries.len());
-        assert_eq!(a, b);
-        assert_eq!(a, c);
-        assert_eq!(
-            a.as_raw() as *const u8 as usize,
-            b.as_raw() as *const u8 as usize
-        );
-        assert_eq!(
-            a.as_raw() as *const u8 as usize,
-            c.as_raw() as *const u8 as usize
-        );
+        assert_eq_sym!(a, b);
+        assert_eq_sym!(a, c);
 
         let d = strtab.intern("bar");
         let e = strtab.intern("bar");
         let f = strtab.intern("foo");
         assert_eq!(2, strtab.entries.len());
-        assert_eq!(d, e);
-        assert_eq!(a, f);
-        assert_eq!(
-            d.as_raw() as *const u8 as usize,
-            e.as_raw() as *const u8 as usize
-        );
-        assert_eq!(
-            a.as_raw() as *const u8 as usize,
-            f.as_raw() as *const u8 as usize
-        );
+        assert_eq_sym!(d, e);
+        assert_eq_sym!(a, f);
     }
 
     #[test]

--- a/compiler-lib/src/visitor.rs
+++ b/compiler-lib/src/visitor.rs
@@ -13,8 +13,8 @@ pub enum NodeKind<'a, 't> {
     ClassMember(&'a Spanned<'t, ClassMember<'t>>),
     Parameter(&'a Spanned<'t, Parameter<'t>>),
     ParameterList(&'a Spanned<'t, ParameterList<'t>>),
-    Type(&'a Spanned<'t, Type>),
-    BasicType(&'a BasicType),
+    Type(&'a Spanned<'t, Type<'t>>),
+    BasicType(&'a BasicType<'t>),
     Block(&'a Spanned<'t, Block<'t>>),
     Stmt(&'a Spanned<'t, Stmt<'t>>),
     Expr(&'a Spanned<'t, Expr<'t>>),
@@ -198,8 +198,8 @@ gen_from_ast!(
     NodeKind::ParameterList<'a, 'f>,
     Spanned<'f, ast::ParameterList<'f>>
 );
-gen_from_ast!(NodeKind::Type<'a, 'f>, Spanned<'f, ast::Type>);
-gen_from_ast!(NodeKind::BasicType<'a, 'f>, ast::BasicType);
+gen_from_ast!(NodeKind::Type<'a, 'f>, Spanned<'f, ast::Type<'f>>);
+gen_from_ast!(NodeKind::BasicType<'a, 'f>, ast::BasicType<'f>);
 gen_from_ast!(NodeKind::Block<'a, 'f>, Spanned<'f, ast::Block<'f>>);
 gen_from_ast!(NodeKind::Stmt<'a, 'f>, Spanned<'f, ast::Stmt<'f>>);
 gen_from_ast!(NodeKind::Expr<'a, 'f>, Spanned<'f, ast::Expr<'f>>);

--- a/inspect-ast/src/main.rs
+++ b/inspect-ast/src/main.rs
@@ -74,8 +74,8 @@ fn do_main(cmd: CliCommand) -> Result<(), Error> {
     let stdout = StandardStream::stdout(ColorChoice::Auto);
     let context = Context::new(&ascii_file, Box::new(stdout));
 
-    let strtab = StringTable::new();
-    let lexer = Lexer::new(&strtab, &context);
+    let mut strtab = StringTable::new();
+    let lexer = Lexer::new(&mut strtab, &context);
 
     // adapt lexer to fail on first error
     // filter whitespace and comments


### PR DESCRIPTION
# Good stuff
- Integer literals are no longer `Symbol`s, but `&str`
- Comments are now zero-copy: `&str`, not `String` 
- Symbols are now zero-copy: The string interner simpliy unifies references into the source-file mapping.
- Symbol comparisions are now by-pointer, but symbols can still be compared to `&str`, then we compare by-value
- No more unsafe code in the strtab: The lexer now gets a `&mut StringTable`, since we don't need to intern new strings outside of the lexer (and the symbols are now refs into the mapping, having nothing to do with the strtab) this works

# Bad stuff (breaking changes)
- `Symbol` and `TokenKind` now have a lifetime parameter