### PR TITLE
Correct display of possibly expected tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mjtest 0.0.1",
  "mjtest_macros 0.0.1",
  "strum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -129,6 +130,11 @@ dependencies = [
 [[package]]
 name = "difference"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -194,6 +200,14 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -580,11 +594,13 @@ dependencies = [
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f57d78cf3bd45270dad4e70c21ec77a960b36c7a841ff9db76aaa775a8fb871"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"

--- a/compiler-cli/integration-tests/parser/BlockStmt_LocalVarDeclStmt.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/BlockStmt_LocalVarDeclStmt.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ';', found identifier 'ident'
+error: expected `.`, `;`, `[` or a binary operator, found identifier `ident`
    | 
  3 |         ident[3] ident;
    |                  ^^^^^

--- a/compiler-cli/integration-tests/parser/BlockStmt_Stmt.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/BlockStmt_Stmt.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found operator ';'
+error: expected `[` or an identifier, found `;`
    | 
  3 |         ident[];
    |                ^

--- a/compiler-cli/integration-tests/parser/CallArrayElement.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/CallArrayElement.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ';', found operator '('
+error: expected `.`, `;`, `[` or a binary operator, found `(`
    | 
  4 |         ident[ident]();
    |                     ^

--- a/compiler-cli/integration-tests/parser/NonPublicField.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/NonPublicField.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found keyword 'int'
+error: expected 'public' or `}`, found 'int'
    | 
  3 |     int field;
    |     ^^^

--- a/compiler-cli/integration-tests/parser/arrayCreation.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/arrayCreation.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found operator ']'
+error: expected 'false', 'new', 'null', 'this', 'true', `(`, a unary operator, an identifier or an integer literal, found `]`
    | 
  3 |         new int[][][];
    |                 ^

--- a/compiler-cli/integration-tests/parser/array_access.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/array_access.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found operator ']'
+error: expected 'false', 'new', 'null', 'this', 'true', `(`, a unary operator, an identifier or an integer literal, found `]`
    | 
  4 |         a = array[4][];
    |                      ^

--- a/compiler-cli/integration-tests/parser/array_keyword.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/array_keyword.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword `int`, `boolean`, `void` or an identifier, found keyword 'package'
+error: expected 'boolean', 'int', 'static', 'void' or an identifier, found 'package'
    | 
  2 |     public package[] foo;
    |            ^^^^^^^

--- a/compiler-cli/integration-tests/parser/basic_type_as_constructor.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/basic_type_as_constructor.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found keyword 'int'
+error: expected an identifier, found 'int'
    | 
  3 |         return new int();
    |                    ^^^

--- a/compiler-cli/integration-tests/parser/bell.mj.stderr
+++ b/compiler-cli/integration-tests/parser/bell.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found identifier 'ring'
+error: expected 'class', found identifier `ring`
    | 
  1 | ring ring ring {\x07} who's there? 
    | ^^^^

--- a/compiler-cli/integration-tests/parser/class_no_block_semicolon.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/class_no_block_semicolon.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator '{', found operator ';'
+error: expected `{`, found `;`
    | 
  1 | class A;
    |        ^

--- a/compiler-cli/integration-tests/parser/class_without_ident.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/class_without_ident.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found operator '{'
+error: expected an identifier, found `{`
    | 
  1 | class {}
    |       ^

--- a/compiler-cli/integration-tests/parser/empty_while.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/empty_while.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found operator '}'
+error: expected 'false', 'if', 'new', 'null', 'return', 'this', 'true', 'while', `(`, `;`, `{`, a unary operator, an identifier or an integer literal, found `}`
    | 
  4 |     }
    |     ^

--- a/compiler-cli/integration-tests/parser/expression_in_class.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/expression_in_class.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found identifier 'here'
+error: expected 'public' or `}`, found identifier `here`
    | 
  2 |     here.I.am();
    |     ^^^^

--- a/compiler-cli/integration-tests/parser/extra_comma_after_parameters.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/extra_comma_after_parameters.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword `int`, `boolean`, `void` or an identifier, found operator ')'
+error: expected 'boolean', 'int', 'void' or an identifier, found `)`
    | 
  2 |     public int[] method(int parameter, int parameter, int parameter, int parameter, int parameter, int parameter,) {}
    |                                                                                                                  ^

--- a/compiler-cli/integration-tests/parser/field_ident_is_keyword.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/field_ident_is_keyword.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found keyword 'class'
+error: expected `[` or an identifier, found 'class'
    | 
  2 |     public void class;
    |                 ^^^^^

--- a/compiler-cli/integration-tests/parser/field_missing_semicolon.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/field_missing_semicolon.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ';', found operator '}'
+error: expected `(` or `;`, found `}`
    | 
  3 | }
    | ^

--- a/compiler-cli/integration-tests/parser/field_private.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/field_private.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found keyword 'private'
+error: expected 'public' or `}`, found 'private'
    | 
  2 |     private int hello;
    |     ^^^^^^^

--- a/compiler-cli/integration-tests/parser/field_type_is_keyword.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/field_type_is_keyword.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword `int`, `boolean`, `void` or an identifier, found keyword 'while'
+error: expected 'boolean', 'int', 'static', 'void' or an identifier, found 'while'
    | 
  2 |     public while testing;
    |            ^^^^^

--- a/compiler-cli/integration-tests/parser/forgotten_assignment.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/forgotten_assignment.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found operator ';'
+error: expected 'false', 'new', 'null', 'this', 'true', `(`, a unary operator, an identifier or an integer literal, found `;`
    | 
  3 |         return to=klass=the=next=;
    |                                  ^

--- a/compiler-cli/integration-tests/parser/globalInitialization.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/globalInitialization.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ';', found operator '='
+error: expected `(` or `;`, found `=`
    | 
  2 |     public boolean ident = false;
    |                          ^

--- a/compiler-cli/integration-tests/parser/illegal_character.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/illegal_character.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found keyword 'public'
+error: expected 'class', found 'public'
    | 
  1 | public static void illegalIdentifier$() {}
    | ^^^^^^

--- a/compiler-cli/integration-tests/parser/illegal_string_quotes.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/illegal_string_quotes.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found identifier 'System'
+error: expected 'class', found identifier `System`
    | 
  1 | System.out.println("Hello world!");
    | ^^^^^^

--- a/compiler-cli/integration-tests/parser/interface.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/interface.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found keyword 'interface'
+error: expected 'class', found 'interface'
    | 
  1 | interface Foo {}
    | ^^^^^^^^^

--- a/compiler-cli/integration-tests/parser/invalid_class_decl.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/invalid_class_decl.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found integer literal '42'
+error: expected an identifier, found integer literal `42`
    | 
  1 | class 42 {
    |       ^^

--- a/compiler-cli/integration-tests/parser/main_as_statement.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/main_as_statement.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator '{', found operator ';'
+error: expected 'throws' or `{`, found `;`
    | 
  2 |     public static void IDENT(String[]ident);
    |                                            ^

--- a/compiler-cli/integration-tests/parser/main_string_array_expression.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/main_string_array_expression.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ']', found integer literal '5'
+error: expected `]`, found integer literal `5`
    | 
  2 | public static void method(String[5]a){}
    |                                  ^

--- a/compiler-cli/integration-tests/parser/method_missing_ident.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_missing_ident.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found operator '('
+error: expected `[` or an identifier, found `(`
    | 
  2 | public void(){}
    |            ^

--- a/compiler-cli/integration-tests/parser/method_missing_parameter.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_missing_parameter.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword `int`, `boolean`, `void` or an identifier, found operator ','
+error: expected 'boolean', 'int', 'void', `)` or an identifier, found `,`
    | 
  2 | public Chicken likes(,eating corn) {}
    |                      ^

--- a/compiler-cli/integration-tests/parser/method_multiple_brackets.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_multiple_brackets.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator '{', found operator '('
+error: expected 'throws' or `{`, found `(`
    | 
  2 |     public int b()() {}
    |                   ^

--- a/compiler-cli/integration-tests/parser/method_not_public.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_not_public.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found keyword 'int'
+error: expected 'public' or `}`, found 'int'
    | 
  4 |     int actualSolution()  {
    |     ^^^

--- a/compiler-cli/integration-tests/parser/method_private.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_private.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found keyword 'private'
+error: expected 'public' or `}`, found 'private'
    | 
  2 | private void method(){}
    | ^^^^^^^

--- a/compiler-cli/integration-tests/parser/method_two_types.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_two_types.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found keyword 'int'
+error: expected `[` or an identifier, found 'int'
    | 
  2 |     public void int a() {}
    |                 ^^^

--- a/compiler-cli/integration-tests/parser/method_with_semicolon.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/method_with_semicolon.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found operator ';'
+error: expected 'public' or `}`, found `;`
    | 
  2 |     public int b() {};
    |                      ^

--- a/compiler-cli/integration-tests/parser/missing_class_keyword.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/missing_class_keyword.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found identifier 'A'
+error: expected 'class', found identifier `A`
    | 
  1 | A {
    | ^

--- a/compiler-cli/integration-tests/parser/missing_method_body.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/missing_method_body.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator '{', found operator '}'
+error: expected 'throws' or `{`, found `}`
    | 
  3 | }
    | ^

--- a/compiler-cli/integration-tests/parser/missing_parentheses_expression.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/missing_parentheses_expression.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ')', found operator ';'
+error: expected `)`, `.`, `[` or a binary operator, found `;`
    | 
  7 |         d = ((((a + b) * c) - a) / (c % d + ((b - 1) * c));
    |                                                           ^

--- a/compiler-cli/integration-tests/parser/missing_semicolons.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/missing_semicolons.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ';', found keyword 'else'
+error: expected `.`, `;`, `[` or a binary operator, found 'else'
    | 
  5 |         else false
    |         ^^^^

--- a/compiler-cli/integration-tests/parser/nested_classes.invalid.java.stderr
+++ b/compiler-cli/integration-tests/parser/nested_classes.invalid.java.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'public', found keyword 'class'
+error: expected 'public' or `}`, found 'class'
    | 
  2 |     class Inner {
    |     ^^^^^

--- a/compiler-cli/integration-tests/parser/nested_methods.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/nested_methods.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found keyword 'public'
+error: expected 'boolean', 'false', 'if', 'int', 'new', 'null', 'return', 'this', 'true', 'void', 'while', `(`, `;`, `{`, `}`, a unary operator, an identifier or an integer literal, found 'public'
    | 
  3 |         public String bar() {
    |         ^^^^^^

--- a/compiler-cli/integration-tests/parser/pre_decr.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/pre_decr.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found operator '--'
+error: expected 'boolean', 'false', 'if', 'int', 'new', 'null', 'return', 'this', 'true', 'void', 'while', `(`, `;`, `{`, `}`, a unary operator, an identifier or an integer literal, found `--`
    | 
  3 |         --onlyOneToken;
    |         ^^

--- a/compiler-cli/integration-tests/parser/pre_incr_vs_pre_decr.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/pre_incr_vs_pre_decr.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found operator '++'
+error: expected 'false', 'new', 'null', 'this', 'true', `(`, a unary operator, an identifier or an integer literal, found `++`
    | 
  3 |         - -thisIsTotallyFine - !!!++butThisIsNot;
    |                                   ^^

--- a/compiler-cli/integration-tests/parser/primary_expr_as_field_access.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/primary_expr_as_field_access.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found keyword 'null'
+error: expected an identifier, found 'null'
    | 
  3 |         1234.null;
    |              ^^^^

--- a/compiler-cli/integration-tests/parser/surplus_else.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/surplus_else.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected primary expression, found keyword 'else'
+error: expected 'boolean', 'false', 'if', 'int', 'new', 'null', 'return', 'this', 'true', 'void', 'while', `(`, `;`, `{`, `}`, a unary operator, an identifier or an integer literal, found 'else'
     | 
  12 |         else return false;
     |         ^^^^

--- a/compiler-cli/integration-tests/parser/test.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/test.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator '{', found identifier 'B'
+error: expected `{`, found identifier `B`
    | 
  1 | class A B {}
    |         ^

--- a/compiler-cli/integration-tests/parser/throwing_with_keywords.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/throwing_with_keywords.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected an identifier, found keyword 'int'
+error: expected an identifier, found 'int'
    | 
  2 |     public static void main(String[] _what_) throws int {
    |                                                     ^^^

--- a/compiler-cli/integration-tests/parser/top_level_method.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/top_level_method.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found keyword 'public'
+error: expected 'class', found 'public'
    | 
  1 | public static void main(String[] args) {
    | ^^^^^^

--- a/compiler-cli/integration-tests/parser/trailing_param_sep.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/trailing_param_sep.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected operator ')', found operator ','
+error: expected `)`, found `,`
    | 
  2 |     public static void main(String[] args, )
    |                                          ^

--- a/compiler-cli/integration-tests/parser/unclosedComment.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/unclosedComment.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found keyword 'int'
+error: expected 'class', found 'int'
    | 
  1 | int a = 666;
    | ^^^

--- a/compiler-cli/integration-tests/parser/unknown_char.invalid.mj.stderr
+++ b/compiler-cli/integration-tests/parser/unknown_char.invalid.mj.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'class', found keyword 'void'
+error: expected 'class', found 'void'
    | 
  1 | void #method() {}
    | ^^^^

--- a/compiler-cli/integration-tests/parser/wrong_main_parameter.invalid.java.stderr
+++ b/compiler-cli/integration-tests/parser/wrong_main_parameter.invalid.java.stderr
@@ -1,4 +1,4 @@
-error: expected identifier 'String', found keyword 'int'
+error: expected identifier 'String', found 'int'
    | 
  3 |     public static void main(int[] args) {
    |                             ^^^

--- a/compiler-cli/integration-tests/parser/wrong_main_return_type.invalid.java.stderr
+++ b/compiler-cli/integration-tests/parser/wrong_main_return_type.invalid.java.stderr
@@ -1,4 +1,4 @@
-error: expected keyword 'void', found keyword 'int'
+error: expected 'void', found 'int'
    | 
  2 |     public static int main(String[] args) {}
    |                   ^^^

--- a/compiler-lib/Cargo.toml
+++ b/compiler-lib/Cargo.toml
@@ -17,6 +17,7 @@ termcolor = "1.0.4"
 derive_more = "0.13"
 strum = "0.11.0"
 strum_macros = "0.11.0"
+itertools = "0.7"
 
 [dev-dependencies]
 mjtest = { path = "../mjtest-rs" }

--- a/compiler-lib/src/lexer.rs
+++ b/compiler-lib/src/lexer.rs
@@ -34,7 +34,7 @@ pub type LexicalError<'f> = Spanned<'f, ErrorKind>;
 
 pub type IntLit<'f> = &'f str;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TokenKind<'f> {
     Keyword(Keyword),
     Operator(Operator),

--- a/compiler-lib/src/lexer.rs
+++ b/compiler-lib/src/lexer.rs
@@ -34,29 +34,21 @@ pub type LexicalError<'f> = Spanned<'f, ErrorKind>;
 
 pub type IntLit<'f> = &'f str;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Display)]
+/// Keywords are single-ticked, operators back-ticked
 pub enum TokenKind<'f> {
+    #[display(fmt = "'{}'", _0)]
     Keyword(Keyword),
+    #[display(fmt = "`{}`", _0)]
     Operator(Operator),
+    #[display(fmt = "identifier `{}`", _0)]
     Identifier(Symbol<'f>),
+    #[display(fmt = "integer literal `{}`", _0)]
     IntegerLiteral(IntLit<'f>),
+    #[display(fmt = "a comment")]
     Comment(&'f str),
+    #[display(fmt = "whitespace")]
     Whitespace,
-}
-
-impl fmt::Display for TokenKind<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::TokenKind::*;
-
-        match self {
-            Keyword(keyword) => write!(f, "keyword '{}'", keyword),
-            Operator(operator) => write!(f, "operator '{}'", operator),
-            Identifier(symbol) => write!(f, "identifier '{}'", symbol),
-            IntegerLiteral(symbol) => write!(f, "integer literal '{}'", symbol),
-            Comment(_body) => write!(f, "comment"),
-            Whitespace => write!(f, "whitespace"),
-        }
-    }
 }
 
 #[derive(Debug, Fail)]

--- a/compiler-lib/src/lexer.rs
+++ b/compiler-lib/src/lexer.rs
@@ -34,7 +34,7 @@ pub type LexicalError<'f> = Spanned<'f, ErrorKind>;
 
 pub type IntLit<'f> = &'f str;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord, Display)]
 /// Keywords are single-ticked, operators back-ticked
 pub enum TokenKind<'f> {
     #[display(fmt = "'{}'", _0)]
@@ -96,7 +96,7 @@ pub enum Warning {
     CommentSeparatorInsideComment,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
 pub enum Keyword {
     Abstract,
     Assert,
@@ -284,7 +284,7 @@ impl TryFrom<&str> for Keyword {
 }
 
 // Use non-semantic names, since e.g. '<' might mean more than 'less-than'
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
 pub enum Operator {
     ExclaimEqual,
     Exclaim,

--- a/compiler-lib/src/parser.rs
+++ b/compiler-lib/src/parser.rs
@@ -136,7 +136,7 @@ impl<'f> fmt::Display for Alternatives<'f> {
             write!(f, "{}", alternatives[0])
         } else {
             let last = alternatives.pop().unwrap();
-            let alts = alternatives.drain(..alternatives.len() - 1).format(", ");
+            let alts = alternatives.drain(..).format(", ");
             write!(f, "{} or {}", alts, last)
         }
     }

--- a/compiler-lib/src/parser.rs
+++ b/compiler-lib/src/parser.rs
@@ -61,7 +61,7 @@ impl<'f> From<EOF> for MaybeSpanned<'f, SyntaxError> {
     }
 }
 
-pub trait ExpectedToken<'f>: fmt::Debug + fmt::Display {
+pub trait ExpectedToken<'f>: fmt::Debug + fmt::Display + Copy {
     type Yields;
     fn matching(&self, token: &TokenKind<'f>) -> Option<Self::Yields>;
 
@@ -70,23 +70,23 @@ pub trait ExpectedToken<'f>: fmt::Debug + fmt::Display {
     }
 }
 
-#[derive(Debug, Clone, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[display(fmt = "{}", _0)]
 // TODO Should be Copy, but TokenKind contains Rc
 struct Exactly<'f>(TokenKind<'f>);
-#[derive(Debug, Clone, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[display(fmt = "a binary operator")]
 struct BinaryOp;
-#[derive(Debug, Clone, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[display(fmt = "a unary operator")]
 struct UnaryOp;
-#[derive(Debug, Clone, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[display(fmt = "an identifier")]
 struct Identifier;
-#[derive(Debug, Clone, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[display(fmt = "identifier '{}'", _0)]
 struct ExactlyIdentifier<'s>(&'s str);
-#[derive(Debug, Clone, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[display(fmt = "an integer literal")]
 struct IntegerLiteral;
 
@@ -220,7 +220,6 @@ where
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn omnomnom<E>(&mut self, want: E) -> SyntaxResult<'f, Spanned<'f, E::Yields>>
     where
         E: ExpectedToken<'f>,
@@ -241,7 +240,6 @@ where
             })
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn omnomnoptional<E>(&mut self, want: E) -> SyntaxResult<'f, Option<Spanned<'f, E::Yields>>>
     where
         E: ExpectedToken<'f>,
@@ -250,7 +248,6 @@ where
     }
 
     /// Only consume token if pred(E::Yields) holds
-    #[allow(clippy::needless_pass_by_value)]
     fn omnomnoptional_if<E, P>(
         &mut self,
         want: E,
@@ -272,7 +269,6 @@ where
         }))
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn tastes_like<E>(&mut self, want: E) -> SyntaxResult<'f, bool>
     where
         E: ExpectedToken<'f>,
@@ -280,7 +276,6 @@ where
         self.nth_tastes_like(0, want)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn nth_tastes_like<E>(&mut self, n: usize, want: E) -> SyntaxResult<'f, bool>
     where
         E: ExpectedToken<'f>,


### PR DESCRIPTION
Closes #30 

@reiner-dolp I didn't now the easiest way to update the tests (since the output is now different/better)

Disclaimer: I'm not sure if this is a hack or smart. One way or the other, the reason this works even with `SLL(k)` lookahead is rather involved and I'm, like, 90% sure it works in every case.