### PR TITLE
cli/integration-tests: morge granular diff output

### DIFF
--- a/compiler-cli/tests/integration.rs
+++ b/compiler-cli/tests/integration.rs
@@ -171,7 +171,7 @@ fn assert_compiler_phase(phase: CompilerCall, file: &TestFiles) {
     let stderr_changeset = Changeset::new(
         &stderr_expected,
         &normalize_stderr(&String::from_utf8_lossy(&assertion.get_output().stderr)),
-        "\n",
+        " ",
     );
     let stderr_predicate = predicate::function(|actual: &[u8]| {
         normalize_stderr(&String::from_utf8_lossy(actual)) == stderr_expected
@@ -182,7 +182,7 @@ fn assert_compiler_phase(phase: CompilerCall, file: &TestFiles) {
     let stdout_changeset = Changeset::new(
         &stdout_expected,
         &String::from_utf8_lossy(&assertion.get_output().stdout),
-        "\n",
+        " ",
     );
     let stdout_predicate =
         predicate::function(|actual: &[u8]| actual == stdout_expected.as_bytes());


### PR DESCRIPTION
diff words instead of lines.

just followed the upstream differences crate impl of print_diff:
http://johannh.me/difference.rs/src/difference/src/lib.rs.html#169-172