### PR TITLE
rename getter functions

### DIFF
--- a/compiler-lib/src/asciifile/position.rs
+++ b/compiler-lib/src/asciifile/position.rs
@@ -176,7 +176,7 @@ impl<'t> Position<'t> {
     /// let lines = file
     ///     .iter()
     ///     .map(|position| {
-    ///         let line = position.get_line();
+    ///         let line = position.line();
     ///         (position.chr(), line.as_str().to_string())
     ///     })
     ///     .collect::<Vec<_>>();
@@ -210,7 +210,7 @@ impl<'t> Position<'t> {
     ///
     /// Windows style line endings are not considered. This means `'\r'`
     /// will be evaluated as a normal character without any special meaning.
-    pub fn get_line(&self) -> Span<'t> {
+    pub fn line(&self) -> Span<'t> {
         // TODO: this is way more complicated than it has to be, because we are
         // converting our 'NEWLINE in front-position at column 0' convention to
         // a trailing newline convention. But having the newline at the front

--- a/compiler-lib/src/asciifile/span.rs
+++ b/compiler-lib/src/asciifile/span.rs
@@ -223,7 +223,7 @@ impl fmt::Display for Span<'_> {
 /// "abcd\nefgh\nijkl" the iterator will return the following
 /// two lines: ["abcd\n", "efgh\n"]
 ///
-/// Analog to `Position::get_line` this function will append
+/// Analog to `Position::line` this function will append
 /// newlines to the end of each line. This means that `is_mutiline(.)`
 /// will be true, since "\n" is positioned at the next line.
 ///
@@ -254,7 +254,7 @@ impl<'span, 'file> LineIterator<'span, 'file> {
     pub fn new(span: &'span Span<'file>) -> Self {
         Self {
             span,
-            line_to_emit: Some(span.start_position().get_line()),
+            line_to_emit: Some(span.start_position().line()),
         }
     }
 
@@ -275,7 +275,7 @@ impl<'span, 'file> Iterator for LineIterator<'span, 'file> {
                 self.line_to_emit = if self.span.end_position() > line.end_position() {
                     line.end_position()
                         .next()
-                        .map(|first_char| first_char.get_line())
+                        .map(|first_char| first_char.line())
                 } else {
                     None
                 };

--- a/compiler-lib/src/diagnostics.rs
+++ b/compiler-lib/src/diagnostics.rs
@@ -272,7 +272,7 @@ impl<'file, 'msg> Message<'file, 'msg> {
                 // - unwrap(.): both positions are guranteed to exist in the line since we just
                 //   got them from the faulty line, which is a subset of the whole error line
                 let (start_term_pos, end_term_pos) =
-                    line_fmt.get_actual_columns(&faulty_part_of_line).unwrap();
+                    line_fmt.actual_columns(&faulty_part_of_line).unwrap();
 
                 let term_width = end_term_pos - start_term_pos;
 
@@ -382,7 +382,7 @@ impl<'span, 'file> LineFormatter<'span, 'file> {
     /// position.
     ///
     /// Returns `None` if the column is out of bounds.
-    fn get_actual_columns(&self, span: &Span<'_>) -> Option<(usize, usize)> {
+    fn actual_columns(&self, span: &Span<'_>) -> Option<(usize, usize)> {
         let lower = self.len_printed_before(span.start_position().column());
         let upper = self.len_printed_before(span.end_position().column());
 

--- a/compiler-lib/src/symtab.rs
+++ b/compiler-lib/src/symtab.rs
@@ -74,7 +74,7 @@ where
     pub fn visible_definition(&self, sym: S) -> Option<&T> {
         // amortized O(1) lookup to get sym's scope
         let scope = match self.visible_defs.get(&sym) {
-            Some(&idx) => self.get_scope(idx),
+            Some(&idx) => self.scope(idx),
             None => return None,
         };
         // amortized O(1) lookup of symbol in that scope
@@ -93,7 +93,7 @@ where
         }
     }
 
-    fn get_scope(&self, scope_idx: ScopeIdx) -> &SymbolTable<S, T> {
+    fn scope(&self, scope_idx: ScopeIdx) -> &SymbolTable<S, T> {
         match scope_idx {
             ScopeIdx::Root => &self.root,
             ScopeIdx::Dynamic(idx) => &self.scopes[idx],

--- a/compiler-lib/src/type_checking/method_body_typechecker.rs
+++ b/compiler-lib/src/type_checking/method_body_typechecker.rs
@@ -72,7 +72,7 @@ impl<'ctx, 'src, 'sem> MethodBodyTypeChecker<'ctx, 'src, 'sem> {
                 Field(_) => {}
                 Method(_, _, block) | MainMethod(_, block) => {
                     let current_method = current_class
-                        .get_method(member.name)
+                        .method(member.name)
                         .expect("a class only has a member if it exists");
 
                     let mut checker = MethodBodyTypeChecker {
@@ -112,7 +112,7 @@ impl<'ctx, 'src, 'sem> MethodBodyTypeChecker<'ctx, 'src, 'sem> {
             Block(block) => self.check_type_block(block),
             Empty => {}
             If(cond, stmt, opt_else) => {
-                if let Ok(ty) = self.get_type_expr(cond) {
+                if let Ok(ty) = self.type_expr(cond) {
                     if !CheckedType::Boolean.is_assignable_from(&ty.ty) {
                         self.context
                             .report_error(&cond.span, SemanticError::ConditionMustBeBoolean)
@@ -125,7 +125,7 @@ impl<'ctx, 'src, 'sem> MethodBodyTypeChecker<'ctx, 'src, 'sem> {
                 }
             }
             While(cond, stmt) => {
-                if let Ok(ty) = self.get_type_expr(cond) {
+                if let Ok(ty) = self.type_expr(cond) {
                     if !CheckedType::Boolean.is_assignable_from(&ty.ty) {
                         self.context
                             .report_error(&cond.span, SemanticError::ConditionMustBeBoolean)
@@ -135,7 +135,7 @@ impl<'ctx, 'src, 'sem> MethodBodyTypeChecker<'ctx, 'src, 'sem> {
                 self.check_type_stmt(&stmt);
             }
             Expression(expr) => {
-                let _ = self.get_type_expr(expr);
+                let _ = self.type_expr(expr);
             }
             Return(expr_opt) => {
                 let return_ty = &self.current_method.return_ty;
@@ -151,7 +151,7 @@ impl<'ctx, 'src, 'sem> MethodBodyTypeChecker<'ctx, 'src, 'sem> {
                         );
                     }
                     (Some(expr), CheckedType::Void) => {
-                        let _ = self.get_type_expr(expr);
+                        let _ = self.type_expr(expr);
                         self.context
                             .report_error(&stmt.span, SemanticError::VoidMethodCannotReturnValue);
                     }

--- a/compiler-lib/src/type_checking/mod.rs
+++ b/compiler-lib/src/type_checking/mod.rs
@@ -259,23 +259,23 @@ fn add_builtin_types<'src>(
     system_class_def
         .add_field(ClassFieldDef {
             name: strtab.intern("in"),
-            ty: reader_class_def.get_type(),
+            ty: reader_class_def.ty(),
             can_write: false,
         })
         .unwrap();
     system_class_def
         .add_field(ClassFieldDef {
             name: strtab.intern("out"),
-            ty: writer_class_def.get_type(),
+            ty: writer_class_def.ty(),
             can_write: false,
         })
         .unwrap();
     context
         .global_vars
-        .insert(strtab.intern("System"), system_class_def.get_type());
+        .insert(strtab.intern("System"), system_class_def.ty());
 
     let string_class_def = ClassDef::new(strtab.intern("$String"));
-    let string = string_class_def.get_type();
+    let string = string_class_def.ty();
 
     type_system.add_class_def(reader_class_def).unwrap();
     type_system.add_class_def(writer_class_def).unwrap();

--- a/compiler-lib/src/type_checking/type_system.rs
+++ b/compiler-lib/src/type_checking/type_system.rs
@@ -67,7 +67,7 @@ impl<'src> ClassDef<'src> {
         Ok(())
     }
 
-    pub fn get_field(&self, name: Symbol<'src>) -> Option<&ClassFieldDef<'src>> {
+    pub fn field(&self, name: Symbol<'src>) -> Option<&ClassFieldDef<'src>> {
         self.fields.get(&name)
     }
 
@@ -79,11 +79,11 @@ impl<'src> ClassDef<'src> {
         Ok(())
     }
 
-    pub fn get_method(&self, name: Symbol<'src>) -> Option<&ClassMethodDef<'src>> {
+    pub fn method(&self, name: Symbol<'src>) -> Option<&ClassMethodDef<'src>> {
         self.methods.get(&name)
     }
 
-    pub fn get_type(&self) -> CheckedType<'src> {
+    pub fn ty(&self) -> CheckedType<'src> {
         CheckedType::TypeRef(self.name)
     }
 }


### PR DESCRIPTION
See [API-guidelines](https://rust-lang-nursery.github.io/api-guidelines/naming.html?highlight=getter#getter-names-follow-rust-convention-c-getter)

Soon this will be a Clippy lint: rust-lang-nursery/rust-clippy#1673