### PR TITLE
run tests more efficiently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,28 +18,20 @@ matrix:
   include:
     - os: linux
       env: TEST_KIND="comprakt-debug"
+      if: branch != master
     - os: linux
       env: TEST_KIND="comprakt-release"
-
+      if: branch IN (staging, trying, master)
     - os: linux
-      env: TEST_KIND="mjtest-lexer"
-    - os: linux
-      env: TEST_KIND="mjtest-syntax"
-    - os: linux
-      env: TEST_KIND="mjtest-semantic"
+      env: TEST_KIND="mjtest"
+      if: branch != master
     - os: linux
       # only run integration tests, but redirect them
       # through the `build` and `run` scripts. We cannot
       # do this in the other CI builds, since they build
       # `debug` and `release` versions explicitly.
       env: TEST_KIND="submission-system"
-    # Disable until implemented
-    # - os: linux
-    #   env: TEST_KIND="mjtest-ast"
-    # - os: linux
-    #   env: TEST_KIND="mjtest-compile-firm"
-    # - os: linux
-    #   env: TEST_KIND="mjtest-compile"
+      if: branch IN (staging, trying, master)
 
 install: |
     case "$TEST_KIND" in
@@ -47,7 +39,7 @@ install: |
         rustup component add clippy-preview && \
         rustup component add rustfmt-preview;
         ;;
-      mjtest-*)
+      mjtest)
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py --user && \
         pip install typing --user && \
         git clone https://git.scc.kit.edu/IPDSnelting/mjtest.git && \
@@ -77,10 +69,12 @@ script: |
         cargo clippy $FLAGS --all-targets --all-features -- -D warnings && \
         cargo test $FLAGS ;
         ;;
-      mjtest-*)
-        MJTEST_KIND=${TEST_KIND#mjtest-}
+      mjtest)
         cargo build --release && \
-        MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py $MJTEST_KIND ;
+        MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py lexer && \
+        MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py syntax && \
+        MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py ast && \
+        MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py semantic ;
         ;;
       submission-system)
         ./build && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,12 +87,15 @@ script: |
 
 
 after_success: |
-    case "$TEST_KIND" in
-      comprakt-release)
-        cargo doc \
-        && echo '<!doctype html><title>Redirecting...</title><meta http-equiv=refresh content=0;url=compiler_cli/index.html><a href="compiler_cli/index.html">Redirecting to "compiler-cli" crate...</a>' > target/doc/index.html ;
-        ;;
-    esac
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ]
+      then
+        case "$TEST_KIND" in
+          comprakt-release)
+            cargo doc \
+            && echo '<!doctype html><title>Redirecting...</title><meta http-equiv=refresh content=0;url=compiler_cli/index.html><a href="compiler_cli/index.html">Redirecting to "compiler-cli" crate...</a>' > target/doc/index.html ;
+            ;;
+        esac
+    fi
 
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ script: |
         cargo build --release && \
         MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py lexer && \
         MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py syntax && \
-        MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py ast && \
         MJ_TIMEOUT=60 MJ_RUN=target/release/compiler-cli python3 ./mjtest/mjt.py semantic ;
         ;;
       submission-system)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,21 @@ branches:
 matrix:
   include:
     - os: linux
+      name: "Unit and Integration Tests in Debug Mode"
       env: TEST_KIND="comprakt-debug"
-      if: branch != master
+      if: head_branch != master
     - os: linux
+      name: "Unit and Integration Tests in Release Mode"
       env: TEST_KIND="comprakt-release"
-      if: branch IN (staging, trying, master)
+      if: head_branch IN (staging, trying, master)
     - os: linux
+      name: "MjTests via original python script"
       env: TEST_KIND="mjtest"
-      if: branch != master
+      if: head_branch != master
     - os: linux
-      # only run integration tests, but redirect them
-      # through the `build` and `run` scripts. We cannot
-      # do this in the other CI builds, since they build
-      # `debug` and `release` versions explicitly.
+      name: "Submission: Integration tests using build and run scripts"
       env: TEST_KIND="submission-system"
-      if: branch IN (staging, trying, master)
+      if: head_branch IN (staging, trying, master)
 
 install: |
     case "$TEST_KIND" in

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,19 @@ branches:
 matrix:
   include:
     - os: linux
-      name: "Unit and Integration Tests in Debug Mode"
+      name: "unit and integration tests in debug mode"
       env: TEST_KIND="comprakt-debug"
       if: head_branch != master
     - os: linux
-      name: "Unit and Integration Tests in Release Mode"
+      name: "unit and integration tests in release mode"
       env: TEST_KIND="comprakt-release"
       if: head_branch IN (staging, trying, master)
     - os: linux
-      name: "MjTests via original python script"
+      name: "mj-tests via original python script"
       env: TEST_KIND="mjtest"
       if: head_branch != master
     - os: linux
-      name: "Submission: Integration tests using build and run scripts"
+      name: "submission: integration tests using build and run scripts"
       env: TEST_KIND="submission-system"
       if: head_branch IN (staging, trying, master)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - os: linux
       name: "unit and integration tests in release mode"
       env: TEST_KIND="comprakt-release"
-      if: head_branch IN (staging, trying, master)
+      if: head_branch = master OR branch IN (staging, trying)
     - os: linux
       name: "mj-tests via original python script"
       env: TEST_KIND="mjtest"
@@ -31,7 +31,7 @@ matrix:
     - os: linux
       name: "submission: integration tests using build and run scripts"
       env: TEST_KIND="submission-system"
-      if: head_branch IN (staging, trying, master)
+      if: head_branch = master OR branch IN (staging, trying)
 
 install: |
     case "$TEST_KIND" in

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,7 @@ script: |
 
 
 after_success: |
-    if [ "$TRAVIS_PULL_REQUEST" = "false" ]
-      then
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
         case "$TEST_KIND" in
           comprakt-release)
             cargo doc \


### PR DESCRIPTION
- we have more than 5 concurrent jobs per commit, which results in jobs
  waiting for other jobs to finish.
  => reduce number of jobs, especially for commits. You can invoke
     all CI jobs using `bors try`
- much time is spent building a commit, e.g. in the mj-test case
  => merge them into one job
- commits are currently built 3 times: once after commit, once during
  staging and once on master.
  => only built everything during staging. master only builds stuff for
     deployment (and submission since philipp is paranoid)

### New Job Matrix

|                       | PR commit | Trying | Staging | Master |
|----------------------:|:----------|:-------|:--------|:-------|
| build docs            | no        | no     | no      | yes    |
| mjtests               | yes       | yes    | yes     | no     |
| integration (release) | no        | yes    | yes     | yes    |
| unit tests  (release) | no        | yes    | yes     | yes    |
| integration (debug)   | yes       | yes    | yes     | no     |
| unit tests  (debug)   | yes       | yes    | yes     | no     |
| submission            | no        | yes    | yes     | yes    |