### PR TITLE
Rusty abstractions for libfirm bindings by problame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libfirm-rs"
 version = "0.0.1"
 dependencies = [
+ "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libfirm-rs-bindings 0.0.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "inspect-ast"
 version = "0.1.0"
 dependencies = [
@@ -421,6 +426,7 @@ name = "libfirm-rs-bindings"
 version = "0.0.1"
 dependencies = [
  "bindgen 0.42.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflections 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -535,6 +541,13 @@ dependencies = [
  "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "play-libfirm"
+version = "0.1.0"
+dependencies = [
+ "libfirm-rs-bindings 0.0.1",
 ]
 
 [[package]]
@@ -997,6 +1010,7 @@ dependencies = [
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
+"checksum inflections 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itertools-num 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "83ca7b70b838f2e34bc6c2f367a1ed1cfe34fb82464adecadd31cdcc7da882fc"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,14 +545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "play-libfirm"
-version = "0.1.0"
-dependencies = [
- "libfirm-rs 0.0.1",
- "libfirm-rs-bindings 0.0.1",
-]
-
-[[package]]
 name = "predicates"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
 name = "play-libfirm"
 version = "0.1.0"
 dependencies = [
+ "libfirm-rs 0.0.1",
  "libfirm-rs-bindings 0.0.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "inspect-ast",
     "libfirm-rs-bindings",
     "libfirm-rs",
+    "play-libfirm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,4 @@ members = [
     "inspect-ast",
     "libfirm-rs-bindings",
     "libfirm-rs",
-    "play-libfirm",
 ]

--- a/libfirm-rs-bindings/Cargo.toml
+++ b/libfirm-rs-bindings/Cargo.toml
@@ -14,3 +14,4 @@ edition = "2018"
 
 [build-dependencies]
 bindgen = "0.42"
+inflections = "*"

--- a/libfirm-rs-bindings/build.rs
+++ b/libfirm-rs-bindings/build.rs
@@ -25,20 +25,20 @@ enum ConstifiedEnumRewrite {
     WithEnumPrefix(&'static str, Option<&'static str>),
     /// enum_name is something like `Some("ir_relation")`
     /// variant is something like `ir_relation_.*`
-    Solo(&'static str),
+    Solo(&'static str, Option<&'static str>),
 }
 
 impl ConstifiedEnumRewrite {
     fn bindgen_module_name(&self) -> String {
         match self {
             ConstifiedEnumRewrite::WithEnumPrefix(n, _) => format!("{}", n),
-            ConstifiedEnumRewrite::Solo(n) => format!("{}", n),
+            ConstifiedEnumRewrite::Solo(n, _) => format!("{}", n),
         }
     }
     fn bindgen_enum_name(&self) -> String {
         match self {
             ConstifiedEnumRewrite::WithEnumPrefix(n, _) => format!("enum {}", n),
-            ConstifiedEnumRewrite::Solo(n) => format!("{}", n),
+            ConstifiedEnumRewrite::Solo(n, _) => format!("{}", n),
         }
     }
     fn trim_start_matches_prefix(&self) -> String {
@@ -47,7 +47,8 @@ impl ConstifiedEnumRewrite {
                 format!("{}", strip_prefix)
             }
             ConstifiedEnumRewrite::WithEnumPrefix(n, None) => format!("{}_", n),
-            ConstifiedEnumRewrite::Solo(n) => format!("{}_", n),
+            ConstifiedEnumRewrite::Solo(n, None) => format!("{}_", n),
+            ConstifiedEnumRewrite::Solo(_, Some(strip_prefix)) => format!("{}", strip_prefix),
         }
     }
 }
@@ -160,13 +161,108 @@ fn main() {
         // comments include code examples which don't work without using self
         .generate_comments(false);
 
+    use self::ConstifiedEnumRewrite::*;
+    #[rustfmt::skip]
     let enum_rewriter = EnumRewriter::from_rewrites(vec![
-        ConstifiedEnumRewrite::WithEnumPrefix("mtp_additional_properties", Some("mtp_")),
-        ConstifiedEnumRewrite::WithEnumPrefix("ir_relation", None),
-        ConstifiedEnumRewrite::Solo("pn_Cond"),
-        ConstifiedEnumRewrite::Solo("pn_Load"),
-        ConstifiedEnumRewrite::Solo("pn_Store"),
-        ConstifiedEnumRewrite::WithEnumPrefix("ir_cons_flags", Some("cons_")),
+
+        // Bulk edited
+        WithEnumPrefix("op_pin_state", None),
+        WithEnumPrefix("cond_jmp_predicate", Some("COND_JMP_PRED_")),
+        WithEnumPrefix("ir_builtin_kind", Some("ir_bk_")),
+        WithEnumPrefix("float_int_conversion_overflow_style_t", Some("ir_overflow_")),
+        WithEnumPrefix("ir_linkage", Some("IR_LINKAGE_")),
+        WithEnumPrefix("ir_initializer_kind_t", Some("IR_INITIALIZER_")),
+        WithEnumPrefix("ptr_access_kind", Some("ptr_access_")),
+        WithEnumPrefix("tp_opcode", Some("tpo_")),
+        WithEnumPrefix("__codecvt_result", Some("__codecvt_")),
+        WithEnumPrefix("osr_flags", Some("osr_flag_")),
+        WithEnumPrefix("ir_mode_arithmetic", Some("irma_")),
+        WithEnumPrefix("asm_constraint_flags_t", Some("ASM_CONSTRAINT_FLAG_")),
+        WithEnumPrefix("firm_kind", Some("k_")),
+        WithEnumPrefix("ir_opcode", Some("iro_")),
+        WithEnumPrefix("ir_edge_kind_t", Some("EDGE_KIND_")),
+        WithEnumPrefix("ir_relation", None),
+        WithEnumPrefix("ir_resources_t", Some("IR_RESOURCE_")),
+        WithEnumPrefix("ir_graph_constraints_t", Some("IR_GRAPH_CONSTRAINT_")),
+        WithEnumPrefix("ir_graph_properties_t", Some("IR_GRAPH_PROPERTY_")),
+        WithEnumPrefix("ir_alias_relation", Some("ir_")),
+        WithEnumPrefix("ir_entity_usage_computed_state", Some("ir_entity_usage_")),
+        WithEnumPrefix("ir_disambiguator_options", Some("aa_opt_")),
+        WithEnumPrefix("ir_segment_t", Some("IR_SEGMENT_")),
+        WithEnumPrefix("irp_resources_t", Some("IRP_RESOURCE_")),
+        WithEnumPrefix("ikind", Some("INTRINSIC_")),
+        WithEnumPrefix("ir_platform_type_t", Some("IR_TYPE_")),
+        WithEnumPrefix("range_types", Some("VRP_")),
+        WithEnumPrefix("mtp_additional_properties", Some("mtp_")),
+        WithEnumPrefix("ir_cons_flags", Some("cons_")),
+
+        Solo("ir_volatility", Some("volatility_")),
+        Solo("ir_align", Some("align_")),
+        Solo("ir_visibility", None),
+        Solo("ir_entity_usage", Some("ir_usage_")),
+        Solo("inh_transitive_closure_state", Some("inh_transitive_closure_")),
+        Solo("ir_type_state", Some("layout_")),
+        Solo("calling_convention", Some("cc_")),
+        Solo("dwarf_source_language", Some("DW_LANG_")),
+        Solo("irp_callgraph_state", Some("irp_callgraph_")),
+        Solo("loop_nesting_depth_state", Some("loop_nesting_depth_")),
+        Solo("dbg_action", Some("dbg_")),
+        Solo("op_arity", Some("oparity_")),
+        Solo("irop_flags", Some("irop_flag_")),
+        Solo("dump_reason_t", Some("dump_node_")),
+        Solo("n_ASM", None),
+        Solo("pn_ASM", None),
+        Solo("n_Add", None),
+        Solo("n_Alloc", None),
+        Solo("pn_Alloc", None),
+        Solo("n_Anchor", None),
+        Solo("n_And", None),
+        Solo("n_Bitcast", None),
+        Solo("n_Builtin", None),
+        Solo("pn_Builtin", None),
+        Solo("n_Call", None),
+        Solo("pn_Call", None),
+        Solo("n_Cmp", None),
+        Solo("n_Cond", None),
+        Solo("n_Confirm", None),
+        Solo("n_Conv", None),
+        Solo("n_CopyB", None),
+        Solo("n_Div", None),
+        Solo("pn_Div", None),
+        Solo("n_Eor", None),
+        Solo("n_Free", None),
+        Solo("n_IJmp", None),
+        Solo("n_Id", None),
+        Solo("n_Load", None),
+        Solo("n_Member", None),
+        Solo("n_Minus", None),
+        Solo("n_Mod", None),
+        Solo("pn_Mod", None),
+        Solo("n_Mul", None),
+        Solo("n_Mulh", None),
+        Solo("n_Mux", None),
+        Solo("n_Not", None),
+        Solo("n_Or", None),
+        Solo("n_Pin", None),
+        Solo("n_Proj", None),
+        Solo("n_Raise", None),
+        Solo("pn_Raise", None),
+        Solo("n_Return", None),
+        Solo("n_Sel", None),
+        Solo("n_Shl", None),
+        Solo("n_Shr", None),
+        Solo("n_Shrs", None),
+        Solo("pn_Start", None),
+        Solo("n_Store", None),
+        Solo("n_Sub", None),
+        Solo("n_Switch", None),
+        Solo("pn_Switch", None),
+        Solo("ir_dump_verbosity_t", Some("dump_verbosity_")),
+        Solo("ir_dump_flags_t", Some("ir_dump_flag_")),
+        Solo("irg_callee_info_state", Some("irg_callee_info_")),
+        Solo("pn_Cond", None),
+        Solo("pn_Load", None),
+        Solo("pn_Store", None),
     ]);
 
     let builder = builder.parse_callbacks(Box::new(enum_rewriter.clone()));

--- a/libfirm-rs-bindings/build.rs
+++ b/libfirm-rs-bindings/build.rs
@@ -18,6 +18,98 @@ fn cargo_envpath(varname: &str) -> PathBuf {
 
 use std::fs;
 
+#[derive(Debug, Clone, Copy)]
+enum ConstifiedEnumRewrite {
+    /// enum_name is something like `Some("enum ir_relation")`
+    /// variant is something like `ir_relation_.*`
+    WithEnumPrefix(&'static str, Option<&'static str>),
+    /// enum_name is something like `Some("ir_relation")`
+    /// variant is something like `ir_relation_.*`
+    Solo(&'static str),
+}
+
+impl ConstifiedEnumRewrite {
+    fn bindgen_module_name(&self) -> String {
+        match self {
+            ConstifiedEnumRewrite::WithEnumPrefix(n, _) => format!("{}", n),
+            ConstifiedEnumRewrite::Solo(n) => format!("{}", n),
+        }
+    }
+    fn bindgen_enum_name(&self) -> String {
+        match self {
+            ConstifiedEnumRewrite::WithEnumPrefix(n, _) => format!("enum {}", n),
+            ConstifiedEnumRewrite::Solo(n) => format!("{}", n),
+        }
+    }
+    fn trim_start_matches_prefix(&self) -> String {
+        match self {
+            ConstifiedEnumRewrite::WithEnumPrefix(_, Some(strip_prefix)) => {
+                format!("{}", strip_prefix)
+            }
+            ConstifiedEnumRewrite::WithEnumPrefix(n, None) => format!("{}_", n),
+            ConstifiedEnumRewrite::Solo(n) => format!("{}_", n),
+        }
+    }
+}
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+struct EnumRewriter {
+    rules: Vec<ConstifiedEnumRewrite>,
+    rewrites: HashMap<String, String>, // bindgen_enum_name => trim_start_matches prefix
+}
+
+impl EnumRewriter {
+    fn from_rewrites(rules: Vec<ConstifiedEnumRewrite>) -> Self {
+        let mut rewrites = HashMap::new();
+        for rule in &rules {
+            let res = rewrites.insert(rule.bindgen_enum_name(), rule.trim_start_matches_prefix());
+            debug_assert!(
+                res.is_none(),
+                "duplicate in constified_enum_rewrites: {:?}",
+                rule
+            );
+        }
+        return EnumRewriter { rewrites, rules };
+    }
+    fn builder_with_rewrites(&self, builder: bindgen::Builder) -> bindgen::Builder {
+        let mut builder = builder;
+        for rule in &self.rules {
+            builder = builder.constified_enum_module(rule.bindgen_module_name());
+        }
+        return builder;
+    }
+}
+
+use bindgen::callbacks::*;
+use inflections::case;
+
+impl bindgen::callbacks::ParseCallbacks for EnumRewriter {
+    fn enum_variant_name(
+        &self,
+        enum_name: Option<&str>,
+        original_variant_name: &str,
+        variant_value: EnumVariantValue,
+    ) -> Option<String> {
+        if let Some(trim_prefix) = enum_name.and_then(|n| self.rewrites.get(n)) {
+            let trimmed = original_variant_name.trim_start_matches(trim_prefix);
+            let rewritten = case::to_pascal_case(trimmed);
+            println!(
+                "rewriting {:?} {:?} => {:?}",
+                rewritten, original_variant_name, rewritten,
+            );
+            return Some(rewritten);
+        }
+
+        println!(
+            "unhandled: {:?} {:?} {:?}",
+            enum_name, original_variant_name, variant_value
+        );
+        return None;
+    }
+}
+
 fn main() {
     let libfirm_src = cargo_envpath("CARGO_MANIFEST_DIR").join("libfirm");
     let libfirm_src = fs::canonicalize(&libfirm_src).expect(&format!(
@@ -59,16 +151,28 @@ fn main() {
     tell_cargo!("rustc-link-search", libfirm_lib_dir.display());
     tell_cargo!("rustc-link-lib=static", "firm");
 
-    let bindings = bindgen::Builder::default()
+    let builder = bindgen::Builder::default()
         .header("wrapper.h")
         .clang_args(&[&format!("-I{}", libfirm_include_dir.display())])
         // bindgen's own tests fail on that, see
         // https://github.com/rust-lang-nursery/rust-bindgen/issues/550#issuecomment-283438998
         .blacklist_type("max_align_t")
         // comments include code examples which don't work without using self
-        .generate_comments(false)
-        .generate()
-        .expect("Failed to generate bindings");
+        .generate_comments(false);
+
+    let enum_rewriter = EnumRewriter::from_rewrites(vec![
+        ConstifiedEnumRewrite::WithEnumPrefix("mtp_additional_properties", Some("mtp_")),
+        ConstifiedEnumRewrite::WithEnumPrefix("ir_relation", None),
+        ConstifiedEnumRewrite::Solo("pn_Cond"),
+        ConstifiedEnumRewrite::Solo("pn_Load"),
+        ConstifiedEnumRewrite::Solo("pn_Store"),
+        ConstifiedEnumRewrite::WithEnumPrefix("ir_cons_flags", Some("cons_")),
+    ]);
+
+    let builder = builder.parse_callbacks(Box::new(enum_rewriter.clone()));
+    let builder = enum_rewriter.builder_with_rewrites(builder);
+
+    let bindings = builder.generate().expect("Failed to generate bindings");
 
     let out_path = cargo_envpath("OUT_DIR").join("bindings.rs");
     bindings

--- a/libfirm-rs-bindings/src/lib.rs
+++ b/libfirm-rs-bindings/src/lib.rs
@@ -6,6 +6,7 @@
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// A little more idiomatic access to the mode_* statics.
+#[rustfmt::skip]
 pub mod mode {
     pub use super::mode_ANY as Any;
     pub use super::mode_BAD as BAD;
@@ -29,6 +30,7 @@ pub mod mode {
 }
 
 /// A little more idiomatic access to the op_* statics.
+#[rustfmt::skip]
 pub mod op {
     pub use super::op_ASM as ASM;
     pub use super::op_Add as Add;
@@ -86,5 +88,3 @@ pub mod op {
     pub use super::op_Tuple as Tuple;
     pub use super::op_Unknown as Unknown;
 }
-
-

--- a/libfirm-rs-bindings/src/lib.rs
+++ b/libfirm-rs-bindings/src/lib.rs
@@ -5,7 +5,7 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-/// A little more idiomatic access to the mode_* globals
+/// A little more idiomatic access to the mode_* statics.
 pub mod mode {
     pub use super::mode_ANY as Any;
     pub use super::mode_BAD as BAD;
@@ -26,3 +26,64 @@ pub mod mode {
     pub use super::mode_X as X;
     pub use super::mode_b as b;
 }
+
+/// A little more idiomatic access to the op_* statics.
+pub mod op {
+    pub use super::op_ASM as ASM;
+    pub use super::op_Add as Add;
+    pub use super::op_Address as Address;
+    pub use super::op_Align as Align;
+    pub use super::op_Alloc as Alloc;
+    pub use super::op_Anchor as Anchor;
+    pub use super::op_And as And;
+    pub use super::op_Bad as Bad;
+    pub use super::op_Bitcast as Bitcast;
+    pub use super::op_Block as Block;
+    pub use super::op_Builtin as Builtin;
+    pub use super::op_Call as Call;
+    pub use super::op_Cmp as Cmp;
+    pub use super::op_Cond as Cond;
+    pub use super::op_Confirm as Confirm;
+    pub use super::op_Const as Const;
+    pub use super::op_Conv as Conv;
+    pub use super::op_CopyB as CopyB;
+    pub use super::op_Deleted as Deleted;
+    pub use super::op_Div as Div;
+    pub use super::op_Dummy as Dummy;
+    pub use super::op_End as End;
+    pub use super::op_Eor as Eor;
+    pub use super::op_Free as Free;
+    pub use super::op_IJmp as IJmp;
+    pub use super::op_Id as Id;
+    pub use super::op_Jmp as Jmp;
+    pub use super::op_Load as Load;
+    pub use super::op_Member as Member;
+    pub use super::op_Minus as Minus;
+    pub use super::op_Mod as Mod;
+    pub use super::op_Mul as Mul;
+    pub use super::op_Mulh as Mulh;
+    pub use super::op_Mux as Mux;
+    pub use super::op_NoMem as NoMem;
+    pub use super::op_Not as Not;
+    pub use super::op_Offset as Offset;
+    pub use super::op_Or as Or;
+    pub use super::op_Phi as Phi;
+    pub use super::op_Pin as Pin;
+    pub use super::op_Proj as Proj;
+    pub use super::op_Raise as Raise;
+    pub use super::op_Return as Return;
+    pub use super::op_Sel as Sel;
+    pub use super::op_Shl as Shl;
+    pub use super::op_Shr as Shr;
+    pub use super::op_Shrs as Shrs;
+    pub use super::op_Size as Size;
+    pub use super::op_Start as Start;
+    pub use super::op_Store as Store;
+    pub use super::op_Sub as Sub;
+    pub use super::op_Switch as Switch;
+    pub use super::op_Sync as Sync;
+    pub use super::op_Tuple as Tuple;
+    pub use super::op_Unknown as Unknown;
+}
+
+

--- a/libfirm-rs-bindings/src/lib.rs
+++ b/libfirm-rs-bindings/src/lib.rs
@@ -25,6 +25,7 @@ pub mod mode {
     pub use super::mode_T as T;
     pub use super::mode_X as X;
     pub use super::mode_b as b;
+    pub type Type = *mut super::ir_mode;
 }
 
 /// A little more idiomatic access to the op_* statics.

--- a/libfirm-rs-bindings/src/lib.rs
+++ b/libfirm-rs-bindings/src/lib.rs
@@ -4,3 +4,25 @@
 #![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+/// A little more idiomatic access to the mode_* globals
+pub mod mode {
+    pub use super::mode_ANY as Any;
+    pub use super::mode_BAD as BAD;
+    pub use super::mode_BB as BB;
+    pub use super::mode_Bs as Bs;
+    pub use super::mode_Bu as Bu;
+    pub use super::mode_D as D;
+    pub use super::mode_F as F;
+    pub use super::mode_Hs as Hs;
+    pub use super::mode_Hu as Hu;
+    pub use super::mode_Is as Is;
+    pub use super::mode_Iu as Iu;
+    pub use super::mode_Ls as Ls;
+    pub use super::mode_Lu as Lu;
+    pub use super::mode_M as M;
+    pub use super::mode_P as P;
+    pub use super::mode_T as T;
+    pub use super::mode_X as X;
+    pub use super::mode_b as b;
+}

--- a/libfirm-rs/Cargo.toml
+++ b/libfirm-rs/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 
 [dependencies]
 libfirm-rs-bindings = { path = "../libfirm-rs-bindings" }
+derive_more = "0.13"

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -1,6 +1,6 @@
 pub use libfirm_rs_bindings as bindings;
 
-use libfirm_rs_bindings::ir_type;
+use libfirm_rs_bindings::*;
 
 #[derive(Clone, Copy)]
 pub struct Ty(*mut ir_type);
@@ -14,6 +14,36 @@ impl Into<*mut ir_type> for Ty {
 impl From<*mut ir_type> for Ty {
     fn from(primitive: *mut ir_type) -> Ty {
         Ty(primitive)
+    }
+}
+
+impl Ty {
+    pub fn pointer(self) -> Ty {
+        unsafe { new_type_pointer(self.into()) }.into()
+    }
+}
+
+pub struct PrimitiveType;
+impl PrimitiveType {
+    pub fn from_mode(mode: *mut libfirm_rs_bindings::ir_mode) -> Ty {
+        unsafe { new_type_primitive(mode) }.into()
+    }
+    pub fn isize() -> Ty {
+        unsafe { new_type_primitive(mode::Is) }.into()
+    }
+    pub fn usize() -> Ty {
+        unsafe { new_type_primitive(mode::Iu) }.into()
+    }
+}
+
+pub struct ArrayType;
+
+impl ArrayType {
+    pub fn varlength(element_type: Ty) -> Ty {
+        unsafe { new_type_array(element_type.into(), 0) }.into()
+    }
+    pub fn fixedlength(element_type: Ty, length: usize) -> Ty {
+        unsafe { new_type_array(element_type.into(), length as u32) }.into()
     }
 }
 

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -1,5 +1,64 @@
 pub use libfirm_rs_bindings as bindings;
 
+use libfirm_rs_bindings::ir_type;
+
+#[derive(Clone, Copy)]
+pub struct Ty(*mut ir_type);
+
+impl Into<*mut ir_type> for Ty {
+    fn into(self) -> *mut ir_type {
+        self.0
+    }
+}
+
+impl From<*mut ir_type> for Ty {
+    fn from(primitive: *mut ir_type) -> Ty {
+        Ty(primitive)
+    }
+}
+
+/// Builder for new_type_method
+pub struct FunctionType {
+    params: Vec<Ty>,
+    results: Vec<Ty>,
+}
+
+impl FunctionType {
+    pub fn new() -> Self {
+        FunctionType {
+            params: Vec::new(),
+            results: Vec::new(),
+        }
+    }
+    pub fn param(mut self, ty: Ty) -> FunctionType {
+        self.params.push(ty);
+        self
+    }
+    pub fn res(mut self, res: Ty) -> FunctionType {
+        self.results.push(res);
+        self
+    }
+    pub fn build(self) -> Ty {
+        use libfirm_rs_bindings::*;
+        let ft = unsafe {
+            new_type_method(
+                self.params.len(),
+                self.results.len(),
+                false.into(), // variadic
+                cc_cdecl_set,
+                mtp_additional_properties::NoProperty,
+            )
+        };
+        for (i, param) in self.params.into_iter().enumerate() {
+            unsafe { set_method_param_type(ft, i, param.into()) };
+        }
+        for (i, res) in self.results.into_iter().enumerate() {
+            unsafe { set_method_res_type(ft, i, res.into()) };
+        }
+        Ty(ft)
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -111,6 +111,9 @@ impl Graph {
             Graph { entity, irg }
         }
     }
+
+    pub fn start_block(&self) -> Node { unsafe{ get_irg_start_block(self.irg) }.into() }
+
 }
 
 impl Into<*mut ir_graph> for Graph {
@@ -123,6 +126,17 @@ impl Into<*const ir_graph> for Graph {
     fn into(self) -> *const ir_graph {
         self.irg as *const _
     }
+}
+
+#[derive(Clone,Copy)]
+pub struct Node(*mut ir_node);
+
+impl From<*mut ir_node> for Node {
+    fn from(n: *mut ir_node) -> Node { Node(n) }
+}
+
+impl Into<*mut ir_node> for Node {
+    fn into(self) -> *mut ir_node { self.0 }
 }
 
 #[cfg(test)]

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -241,6 +241,12 @@ impl Block {
     pub fn new_sel<P: AsPointer, I: AsIndex>(&self, p: P, i: I, array_type: Ty) -> Sel {
         unsafe { new_r_Sel(self.0, p.as_pointer(), i.as_index(), array_type.into()) }.into()
     }
+
+    /// FIXME: either generate methods for all `ir_op` or use `ir_op` as
+    /// parameter.
+    pub fn new_add<A: ALUOperand, B: ALUOperand>(&self, left: A, right: B) -> ALUOpNode {
+        unsafe { new_r_Add(self.0, left.as_alu_operand(), right.as_alu_operand()) }.into()
+    }
 }
 
 #[derive(Clone, Copy, Into, From)]
@@ -341,9 +347,32 @@ pub struct Sel(*mut ir_node);
 pub struct Const(*mut ir_node);
 
 impl ValueNode for Const {
-    fn as_value_node(&self) -> *mut ir_node { self.0 }
+    fn as_value_node(&self) -> *mut ir_node {
+        self.0
+    }
 }
 
+pub trait ALUOperand {
+    fn as_alu_operand(&self) -> *mut ir_node;
+}
+
+impl<T> ALUOperand for T
+where
+    T: ValueNode,
+{
+    fn as_alu_operand(&self) -> *mut ir_node {
+        self.as_value_node()
+    }
+}
+
+#[derive(Clone, Copy, Into, From)]
+pub struct ALUOpNode(*mut ir_node);
+
+impl ValueNode for ALUOpNode {
+    fn as_value_node(&self) -> *mut ir_node {
+        self.0
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -122,6 +122,7 @@ impl Graph {
         unsafe { set_r_value(self.irg, slot_idx as i32, vn.as_value_node()) }
     }
 
+    /// TODO: have `get_value_$mode::??` for each `mode::??`
     pub fn get_value(&self, slot_idx: usize, mode: mode::Type) -> *mut ir_node {
         unsafe { get_r_value(self.irg, slot_idx as i32, mode) }
     }
@@ -233,6 +234,9 @@ impl Block {
         }
         .into()
     }
+    pub fn new_sel<P: AsPointer, I: AsIndex>(&self, p: P, i: I, array_type: Ty) -> Sel {
+        unsafe { new_r_Sel(self.0, p.as_pointer(), i.as_index(), array_type.into()) }.into()
+    }
 }
 
 #[derive(Clone, Copy, Into, From)]
@@ -299,6 +303,34 @@ impl ValueNode for Projection {
         self.0
     }
 }
+
+pub trait AsPointer {
+    fn as_pointer(&self) -> *mut ir_node;
+}
+
+/// FIXME: remove this quasi-blanket impl because it allows invalid nodes as
+/// AsPointer
+impl AsPointer for *mut ir_node {
+    fn as_pointer(&self) -> *mut ir_node {
+        *self
+    }
+}
+
+pub trait AsIndex {
+    fn as_index(&self) -> *mut ir_node;
+}
+
+/// FIXME: remove this quasi-blanket impl because it allows invalid nodes as
+/// AsIndex
+impl AsIndex for *mut ir_node {
+    fn as_index(&self) -> *mut ir_node {
+        *self
+    }
+}
+
+/// Sel is an `ir_node` representing the result of a by-index selection.
+#[derive(Clone, Copy, Into, From)]
+pub struct Sel(*mut ir_node);
 
 #[cfg(test)]
 mod tests {

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -122,6 +122,10 @@ impl Graph {
         unsafe { set_r_value(self.irg, slot_idx as i32, vn.as_value_node()) }
     }
 
+    pub fn get_value(&self, slot_idx: usize, mode: mode::Type) -> *mut ir_node {
+        unsafe { get_r_value(self.irg, slot_idx as i32, mode) }
+    }
+
     pub fn args_node(&self) -> GraphArgs {
         unsafe { get_irg_args(self.irg) }.into()
     }

--- a/libfirm-rs/src/lib.rs
+++ b/libfirm-rs/src/lib.rs
@@ -136,6 +136,10 @@ impl Graph {
         block.add_pred(pred);
         block
     }
+
+    pub fn new_const(&self, tarval: *mut ir_tarval) -> Const {
+        unsafe { new_r_Const(self.irg, tarval) }.into()
+    }
 }
 
 impl Into<*mut ir_graph> for Graph {
@@ -331,6 +335,15 @@ impl AsIndex for *mut ir_node {
 /// Sel is an `ir_node` representing the result of a by-index selection.
 #[derive(Clone, Copy, Into, From)]
 pub struct Sel(*mut ir_node);
+
+/// Const is an `ir_node` resulting from a new_const operation.
+#[derive(Clone, Copy, Into, From)]
+pub struct Const(*mut ir_node);
+
+impl ValueNode for Const {
+    fn as_value_node(&self) -> *mut ir_node { self.0 }
+}
+
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Pretty much the same as `problame/play-libfirm`, but without the `play-libfirm` crate.