### PR TITLE
 Implement libFirm function generation

### DIFF
--- a/compiler-lib/src/firm.rs
+++ b/compiler-lib/src/firm.rs
@@ -47,7 +47,7 @@ impl<'ir, 'src> FirmGenerator<'ir, 'src> {
                     let mut ft = FunctionType::new();
 
                     // Set param and return types. `main` method has neither
-                    if !is_main {
+                    let method_name = if !is_main {
                         let this_param = ClassType::new_class_type(class.name.as_str());
                         ft.add_param(this_param);
 
@@ -59,13 +59,16 @@ impl<'ir, 'src> FirmGenerator<'ir, 'src> {
                         if let Some(ty) = get_firm_type(&method.return_ty) {
                             ft.set_res(ty);
                         }
-                    }
+                        format!("{}.{}", class.name.data, method.name)
+                    } else {
+                        format!(".{}", method.name)
+                    };
 
                     let method_type = ft.build(is_main);
                     let mut local_var_def_visitor = LocalVarDefVisitor::new();
                     local_var_def_visitor.visit(&NodeKind::from(block));
                     let graph = Graph::function(
-                        &format!("{}::{}", class.name.data, method.name),
+                        &method_name,
                         method_type,
                         method.params.len() + local_var_def_visitor.count,
                     );

--- a/compiler-lib/src/firm.rs
+++ b/compiler-lib/src/firm.rs
@@ -1,5 +1,13 @@
-use libfirm_rs::bindings::*;
-use std::{ffi::CStr, path::PathBuf};
+use crate::{
+    ast::{self, Program, AST},
+    type_checking::type_system::{CheckedType, TypeSystem},
+    visitor::NodeKind,
+};
+use libfirm_rs::{bindings::*, *};
+use std::{
+    ffi::{CStr, CString},
+    path::PathBuf,
+};
 
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -8,61 +16,163 @@ pub struct Options {
     pub dump_assembler: Option<PathBuf>,
 }
 
-pub unsafe fn build(opts: &Options) {
+pub struct FirmGenerator<'ir, 'src> {
+    program: &'ir Program<'src>,
+    type_system: &'ir TypeSystem<'src>,
+}
+
+impl<'ir, 'src> FirmGenerator<'ir, 'src> {
+    fn new(program: &'ir Program<'src>, type_system: &'ir TypeSystem<'src>) -> Self {
+        Self {
+            program,
+            type_system,
+        }
+    }
+
+    fn init_functions(&self) -> Vec<Graph> {
+        let mut fn_graphs = vec![];
+        for class in &self.program.classes {
+            for member in &class.members {
+                if let Some(block) = member.kind.method_body() {
+                    let method = self
+                        .type_system
+                        .defined_classes()
+                        .get(&class.name)
+                        .expect(
+                            "after type checking every class should be defined in the type system",
+                        )
+                        .method(member.name)
+                        .expect("after type checking every method should be deined in it's class");
+                    let is_main = method.is_static;
+                    let mut ft = FunctionType::new();
+
+                    // Set param and return types. `main` method has neither
+                    if !is_main {
+                        let this_param = ClassType::new_class_type(class.name.as_str());
+                        ft.add_param(this_param);
+
+                        for param in &method.params {
+                            let ty = get_firm_type(&param.ty);
+                            ft.add_param(ty.expect("params never have `void` or `null` type"));
+                        }
+
+                        if let Some(ty) = get_firm_type(&method.return_ty) {
+                            ft.set_res(ty);
+                        }
+                    }
+
+                    let method_type = ft.build(is_main);
+                    let mut local_var_def_visitor = LocalVarDefVisitor::new();
+                    local_var_def_visitor.visit(&NodeKind::from(block));
+                    let graph = Graph::function(
+                        &format!("{}::{}", class.name.data, method.name),
+                        method_type,
+                        method.params.len() + local_var_def_visitor.count,
+                    );
+                    let start_block = graph.start_block();
+                    // FIXME: Swap this with body generation
+                    let mem = graph.cur_store();
+                    let ret = start_block.new_return(mem, None);
+                    let end_block = graph.end_block();
+
+                    end_block.add_pred(&ret);
+
+                    unsafe {
+                        mature_immBlock(get_irg_start_block(graph.into()));
+                        irg_finalize_cons(graph.into());
+                    }
+                    fn_graphs.push(graph);
+                }
+            }
+        }
+
+        fn_graphs
+    }
+}
+
+struct LocalVarDefVisitor {
+    count: usize,
+}
+
+impl<'a, 'f> LocalVarDefVisitor {
+    fn new() -> Self {
+        Self { count: 0 }
+    }
+
+    fn visit(&mut self, node: &NodeKind<'a, 'f>) {
+        use self::NodeKind::*;
+        node.for_each_child(&mut |child| {
+            if let Stmt(stmt) = child {
+                if let ast::Stmt::LocalVariableDeclaration(..) = stmt.data {
+                    self.count += 1;
+                }
+            }
+
+            self.visit(&child)
+        });
+    }
+}
+
+fn get_firm_type(ty: &CheckedType<'_>) -> Option<Ty> {
+    match ty {
+        CheckedType::Int => Some(PrimitiveType::i32()),
+        CheckedType::Boolean => Some(PrimitiveType::bool()),
+        CheckedType::TypeRef(name) => Some(ClassType::new_class_type(name.as_str())),
+        CheckedType::Array(checked_type) => Some(
+            get_firm_type(checked_type)
+                .expect("Arrays are never of type `void` or `null`")
+                .pointer(),
+        ),
+        // Not possible
+        CheckedType::Void | CheckedType::Null => None,
+    }
+}
+
+unsafe fn setup() {
     ir_init_library();
 
     // this call panics on error
     let triple = ir_get_host_machine_triple();
     ir_target_set_triple(triple);
-    //print_machine_triple(triple);
 
     // pic=1 means 'generate position independent code'
-    ir_target_option(CStr::from_bytes_with_nul(b"pic=1\0").unwrap().as_ptr());
+    ir_target_option(CString::new("pic=1").expect("CString::new failed").as_ptr());
 
     // The backend can also dump graphs after each step.
-    // You can ignore these as you will be writing your own back end anyway.
     // Note(Reiner): seems undocumented?!
     //ir_target_option(CStr::from_bytes_with_nul(b"dump=all\0").unwrap().as_ptr());
-
     ir_target_init();
 
     set_optimize(0);
+}
 
-    // TODO: build and finalize graph!
+pub unsafe fn build(_opts: &Options, ast: &AST<'_>, type_system: &TypeSystem<'_>) {
+    let program = match ast {
+        ast::AST::Program(program) => program,
+        ast::AST::Empty => unreachable!(),
+    };
+    let firm_gen = FirmGenerator::new(program, type_system);
+    setup();
 
-    if let Some(ref path) = opts.dump_firm_graph {
-        let mut cpath = path.to_string_lossy().to_string();
-        cpath.push('\0');
+    let graphs = firm_gen.init_functions();
 
-        let _cstr = CStr::from_bytes_with_nul(cpath.as_bytes())
-            .unwrap()
-            .as_ptr();
-        //dump_ir_graph(graph, cstr);
-    }
-
-    //lower_highlevel_graph(graph);
-    //be_lower_for_target();
-
-    if let Some(ref path) = opts.dump_lowered_firm_graph {
-        let mut cpath = path.to_string_lossy().to_string();
-        cpath.push('\0');
-
-        let _cstr = CStr::from_bytes_with_nul(cpath.as_bytes())
-            .unwrap()
-            .as_ptr();
-        //dump_ir_graph(graph, cstr);
-    }
-
-    if let Some(ref _path) = opts.dump_assembler {
-        // TODO: open file with C api instead of foring stdout
-        // TODO: print target machine triple, input file name, compiler version
-        // on top of assembler output
-        be_main(
-            stdout,
-            CStr::from_bytes_with_nul(b"<stdin>\0").unwrap().as_ptr(),
+    for graph in graphs {
+        dump_ir_graph(
+            graph.into(),
+            CString::new("ssa-constructed")
+                .expect("CString::new failed")
+                .as_ptr(),
         );
     }
 
+    lower_highlevel();
+    be_lower_for_target();
+    be_main(
+        stdout,
+        CString::new("<stdout>")
+            .expect("CString::new failed")
+            .as_ptr(),
+    );
     ir_finish();
 }
 

--- a/compiler-lib/src/semantics.rs
+++ b/compiler-lib/src/semantics.rs
@@ -3,6 +3,7 @@ use crate::{
     ast,
     context::Context,
     strtab::{self, Symbol},
+    type_checking::type_system::TypeSystem,
     visitor::NodeKind,
 };
 use failure::Fail;
@@ -142,7 +143,7 @@ pub fn check<'a, 'f>(
     strtab: &mut strtab::StringTable<'f>,
     ast: &'a ast::AST<'f>,
     context: &Context<'f>,
-) -> Result<(), ()> {
+) -> Result<TypeSystem<'f>, ()> {
     let mut first_pass_visitor = ClassesAndMembersVisitor::new(context);
     first_pass_visitor.do_visit(&NodeKind::from(ast));
 
@@ -159,11 +160,11 @@ pub fn check<'a, 'f>(
         return Err(());
     }
 
-    crate::type_checking::check(strtab, &ast, &context);
+    let type_system = crate::type_checking::check(strtab, &ast, &context);
     if context.diagnostics.errored() {
         return Err(());
     }
-    Ok(())
+    Ok(type_system)
 }
 
 struct ClassesAndMembersVisitor<'f, 'cx> {

--- a/compiler-lib/src/strtab.rs
+++ b/compiler-lib/src/strtab.rs
@@ -11,6 +11,10 @@ impl Symbol<'_> {
     fn as_raw(&self) -> *const str {
         self.0 as *const str
     }
+
+    pub fn as_str(&self) -> &str {
+        self.0
+    }
 }
 
 impl PartialEq for Symbol<'_> {

--- a/compiler-lib/src/type_checking/type_system.rs
+++ b/compiler-lib/src/type_checking/type_system.rs
@@ -51,6 +51,10 @@ impl<'src> TypeSystem<'src> {
     pub fn lookup_class(&self, name: Symbol<'src>) -> Option<&ClassDef<'src>> {
         self.defined_classes.get(&name)
     }
+
+    pub fn defined_classes(&self) -> &HashMap<Symbol<'_>, ClassDef<'_>> {
+        &self.defined_classes
+    }
 }
 
 /// A `ClassDefId` identifies a class.


### PR DESCRIPTION
cc #117 

When running
```
cargo run -- --lower Foo.java
```
Foo.java:
```java
class Foo {
    public static void main(String[] args) { }
}
```

This will generate
![image](https://user-images.githubusercontent.com/9744647/48919585-f30b3000-ee93-11e8-8fc9-5f085e774584.png)

The `LoweringOptions` aren't used yet. Also it will segfault on every return type except of void.