### PR TITLE
WIP: Added comparable flag to class definitions

### DIFF
--- a/compiler-lib/src/type_checking/builtin_types.rs
+++ b/compiler-lib/src/type_checking/builtin_types.rs
@@ -16,6 +16,7 @@ impl<'src> BuiltinTypes<'src> {
 
         let reader_class_id = {
             let mut reader_class_def = ClassDef::new(strtab.intern("$Reader"));
+            reader_class_def.comparable = false;
             reader_class_def
                 .add_method(ClassMethodDef {
                     name: strtab.intern("read"),
@@ -32,6 +33,7 @@ impl<'src> BuiltinTypes<'src> {
             let arg_sym = strtab.intern("data");
 
             let mut writer_class_def = ClassDef::new(strtab.intern("$Writer"));
+            writer_class_def.comparable = false;
             writer_class_def
                 .add_method(ClassMethodDef {
                     name: strtab.intern("println"),
@@ -64,6 +66,7 @@ impl<'src> BuiltinTypes<'src> {
 
         let system_class_id = {
             let mut system_class_def = ClassDef::new(strtab.intern("$System"));
+            system_class_def.comparable = false;
             system_class_def
                 .add_field(ClassFieldDef {
                     name: strtab.intern("in"),

--- a/compiler-lib/src/type_checking/method_body_type_checker.rs
+++ b/compiler-lib/src/type_checking/method_body_type_checker.rs
@@ -130,7 +130,7 @@ where
             Empty => {}
             If(cond, stmt, opt_else) => {
                 if let Ok(ty) = self.type_expr(cond) {
-                    if !CheckedType::Boolean.is_assignable_from(&ty.ty) {
+                    if !CheckedType::Boolean.is_assignable_from(&ty.ty, self.type_system) {
                         self.context
                             .report_error(&cond.span, SemanticError::ConditionMustBeBoolean)
                     }
@@ -143,7 +143,7 @@ where
             }
             While(cond, stmt) => {
                 if let Ok(ty) = self.type_expr(cond) {
-                    if !CheckedType::Boolean.is_assignable_from(&ty.ty) {
+                    if !CheckedType::Boolean.is_assignable_from(&ty.ty, self.type_system) {
                         self.context
                             .report_error(&cond.span, SemanticError::ConditionMustBeBoolean)
                     }
@@ -404,8 +404,8 @@ where
                 let lhs_type = lhs_info?.ty;
                 let rhs_type = rhs_info?.ty;
 
-                if !lhs_type.is_assignable_from(&rhs_type)
-                    && !rhs_type.is_assignable_from(&lhs_type)
+                if !lhs_type.is_assignable_from(&rhs_type, self.type_system)
+                    && !rhs_type.is_assignable_from(&lhs_type, self.type_system)
                 {
                     self.context.report_error(
                         &span,
@@ -441,7 +441,7 @@ where
         expected_ty: &CheckedType<'src>,
     ) {
         if let Ok(expr_info) = self.type_expr(expr) {
-            if !expected_ty.is_assignable_from(&expr_info.ty) {
+            if !expected_ty.is_assignable_from(&expr_info.ty, self.type_system) {
                 self.context.report_error(
                     &expr.span,
                     SemanticError::InvalidType {

--- a/compiler-lib/src/type_checking/type_system.rs
+++ b/compiler-lib/src/type_checking/type_system.rs
@@ -99,6 +99,7 @@ pub struct ClassDef<'src> {
     pub name: Symbol<'src>,
     fields: HashMap<Symbol<'src>, ClassFieldDef<'src>>,
     methods: HashMap<Symbol<'src>, ClassMethodDef<'src>>,
+    pub comparable: bool,
 }
 
 impl<'src> ClassDef<'src> {
@@ -108,6 +109,7 @@ impl<'src> ClassDef<'src> {
             name,
             fields: HashMap::new(),
             methods: HashMap::new(),
+            comparable: true,
         }
     }
 
@@ -210,21 +212,25 @@ impl<'src> CheckedType<'src> {
         }
     }
 
-    pub fn is_nullable(&self) -> bool {
+    pub fn is_assignable_from(&self, other: &CheckedType<'src>, ts: &'_ TypeSystem) -> bool {
+        use self::CheckedType::*;
         match self {
-            CheckedType::TypeRef(_) => true,
-            CheckedType::UnknownType(_) => true,
-            CheckedType::Array(_) => true,
-            CheckedType::Null => true,
-            _ => false,
+            // dont generate errors for unknown types as they are invalid anyways
+            UnknownType(_) => true,
+            Int | Boolean => self == other,
+            // nothing is assignable to null or void, not even expressions of type void or null.
+            // This does not really matter though as void is not an inhibited type.
+            Null | Void => false,
+            Array(item_ty) => match other {
+                Null => true,
+                Array(other_item_ty) => item_ty.is_assignable_from(other_item_ty, ts),
+                _ => false,
+            },
+            TypeRef(class_id) => {
+                let class_def = ts.class(class_id);
+                class_def.comparable && (self == other || other == Null)
+            }
         }
-    }
-    pub fn is_assignable_from(&self, other: &CheckedType<'src>) -> bool {
-        // FIXME there must be a better way
-        (match other {
-            CheckedType::Null => self.is_nullable(),
-            _ => false,
-        }) || self == other
     }
 }
 


### PR DESCRIPTION
Now, $System, $Reader and $Writer cannot be compared and assigned anymore.
Fixes #115.