### PR TITLE
Add Type Information to `inspect-ast`

### DIFF
--- a/codegen-integration-tests/src/lib.rs
+++ b/codegen-integration-tests/src/lib.rs
@@ -159,7 +159,16 @@ pub fn gen_semantic_integration_tests(_args: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn gen_ast_inspector_tests(_args: TokenStream) -> TokenStream {
     gen_integration_tests("spans", "", |test_name, mj_file| {
-        default_test_generator(&quote! { CompilerCall::AstInspector }, test_name, mj_file)
+        let function_name = Ident::new(&test_name, Span::call_site());
+        let path_str = mj_file.to_str().unwrap();
+
+        quote! {
+            #[test]
+            fn #function_name() {
+                let input = PathBuf::from(#path_str);
+                exec_ast_inspector_test(input);
+            }
+        }
     })
 }
 

--- a/integration-tests/spans/array_access_is_by_value.mj
+++ b/integration-tests/spans/array_access_is_by_value.mj
@@ -1,0 +1,15 @@
+class ArrayAccessIsByValue {
+  public int[] x;
+
+  public int[] foo(int callsite) {
+    System.out.println(callsite);
+    x = new int[2];
+    return x;
+  }
+
+  public static void main(String[] args) {
+    ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    int x = m.foo(1)[m.foo(2)[1]];
+  }
+}
+

--- a/integration-tests/spans/array_access_is_by_value.mj.stdout
+++ b/integration-tests/spans/array_access_is_by_value.mj.stdout
@@ -1,0 +1,270 @@
+info: Matched kind 'program'
+    | 
+  1 | class ArrayAccessIsByValue {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  2 |   public int[] x;
+    | ^^^^^^^^^^^^^^^^^
+  3 | 
+    | 
+  4 |   public int[] foo(int callsite) {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  5 |     System.out.println(callsite);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  6 |     x = new int[2];
+    | ^^^^^^^^^^^^^^^^^^^
+  7 |     return x;
+    | ^^^^^^^^^^^^^
+  8 |   }
+    | ^^^
+  9 | 
+    | 
+ 10 |   public static void main(String[] args) {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 13 |   }
+    | ^^^
+ 14 | }
+    | ^
+
+info: Matched kind 'class declaration'
+    | 
+  1 | class ArrayAccessIsByValue {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  2 |   public int[] x;
+    | ^^^^^^^^^^^^^^^^^
+  3 | 
+    | 
+  4 |   public int[] foo(int callsite) {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  5 |     System.out.println(callsite);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  6 |     x = new int[2];
+    | ^^^^^^^^^^^^^^^^^^^
+  7 |     return x;
+    | ^^^^^^^^^^^^^
+  8 |   }
+    | ^^^
+  9 | 
+    | 
+ 10 |   public static void main(String[] args) {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 13 |   }
+    | ^^^
+ 14 | }
+    | ^
+
+info: Matched kind 'class member'
+   | 
+ 2 |   public int[] x;
+   |   ^^^^^^^^^^^^^^^
+
+info: Matched kind 'type'
+   | 
+ 2 |   public int[] x;
+   |          ^^^^^
+
+info: Matched kind 'class member'
+   | 
+ 4 |   public int[] foo(int callsite) {
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 5 |     System.out.println(callsite);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 6 |     x = new int[2];
+   | ^^^^^^^^^^^^^^^^^^^
+ 7 |     return x;
+   | ^^^^^^^^^^^^^
+ 8 |   }
+   | ^^^
+
+info: Matched kind 'type'
+   | 
+ 4 |   public int[] foo(int callsite) {
+   |          ^^^^^
+
+info: Matched kind 'parameter list'
+   | 
+ 4 |   public int[] foo(int callsite) {
+   |                   ^^^^^^^^^^^^^^
+
+info: Matched kind 'parameter'
+   | 
+ 4 |   public int[] foo(int callsite) {
+   |                    ^^^^^^^^^^^^
+
+info: Matched kind 'type'
+   | 
+ 4 |   public int[] foo(int callsite) {
+   |                    ^^^
+
+info: Matched kind 'block'
+   | 
+ 4 |   public int[] foo(int callsite) {
+   |                                  ^
+ 5 |     System.out.println(callsite);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 6 |     x = new int[2];
+   | ^^^^^^^^^^^^^^^^^^^
+ 7 |     return x;
+   | ^^^^^^^^^^^^^
+ 8 |   }
+   | ^^^
+
+info: Matched kind 'statement'
+   | 
+ 5 |     System.out.println(callsite);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `void associated with method definition 'println'`
+   | 
+ 5 |     System.out.println(callsite);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `reference-type '$Writer' associated with read-only field definition 'out'`
+   | 
+ 5 |     System.out.println(callsite);
+   |     ^^^^^^^^^^
+
+info: Matched kind 'expression' of type `reference-type '$System' associated with global variable 'System'`
+   | 
+ 5 |     System.out.println(callsite);
+   |     ^^^^^^
+
+info: Matched kind 'expression' of type `integer associated with method parameter definition 'callsite'`
+   | 
+ 5 |     System.out.println(callsite);
+   |                        ^^^^^^^^
+
+info: Matched kind 'statement'
+   | 
+ 6 |     x = new int[2];
+   |     ^^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer`
+   | 
+ 6 |     x = new int[2];
+   |     ^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with field definition 'x'`
+   | 
+ 6 |     x = new int[2];
+   |     ^
+
+info: Matched kind 'expression' of type `array of integer`
+   | 
+ 6 |     x = new int[2];
+   |         ^^^^^^^^^^
+
+info: Matched kind 'expression' of type `integer`
+   | 
+ 6 |     x = new int[2];
+   |                 ^
+
+info: Matched kind 'statement'
+   | 
+ 7 |     return x;
+   |     ^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with field definition 'x'`
+   | 
+ 7 |     return x;
+   |            ^
+
+info: Matched kind 'class member'
+    | 
+ 10 |   public static void main(String[] args) {
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 13 |   }
+    | ^^^
+
+info: Matched kind 'block'
+    | 
+ 10 |   public static void main(String[] args) {
+    |                                          ^
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 13 |   }
+    | ^^^
+
+info: Matched kind 'statement'
+    | 
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'type'
+    | 
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    |     ^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `reference-type 'ArrayAccessIsByValue'`
+    | 
+ 11 |     ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'statement'
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'type'
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |     ^^^
+
+info: Matched kind 'expression' of type `integer associated with an array access`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |             ^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with method definition 'foo'`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |             ^^^^^^^^
+
+info: Matched kind 'expression' of type `reference-type 'ArrayAccessIsByValue' associated with local variable definition 'm'`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |             ^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                   ^
+
+info: Matched kind 'expression' of type `integer associated with an array access`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                      ^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with method definition 'foo'`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                      ^^^^^^^^
+
+info: Matched kind 'expression' of type `reference-type 'ArrayAccessIsByValue' associated with local variable definition 'm'`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                      ^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                            ^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                               ^
+

--- a/integration-tests/spans/yaml_example_all_int_or_boolean_expressions.mj
+++ b/integration-tests/spans/yaml_example_all_int_or_boolean_expressions.mj
@@ -1,0 +1,23 @@
+---
+kind: expression
+typeinfo: integer|boolean
+---
+class ArrayAccessIsByValue {
+  public int[] x;
+
+  public int[] foo(int callsite) {
+    System.out.println(callsite);
+    x = new int[2];
+    return x;
+  }
+
+  public static void main(String[] args) {
+    ArrayAccessIsByValue m = new ArrayAccessIsByValue();
+    int x = m.foo(1)[m.foo(2)[1]];
+    
+    if (x > 1) {
+        System.out.println(12);
+    }
+  }
+}
+

--- a/integration-tests/spans/yaml_example_all_int_or_boolean_expressions.mj.stdout
+++ b/integration-tests/spans/yaml_example_all_int_or_boolean_expressions.mj.stdout
@@ -1,0 +1,85 @@
+info: Matched kind 'expression' of type `integer associated with method parameter definition 'callsite'`
+   | 
+ 5 |     System.out.println(callsite);
+   |                        ^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer`
+   | 
+ 6 |     x = new int[2];
+   |     ^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with field definition 'x'`
+   | 
+ 6 |     x = new int[2];
+   |     ^
+
+info: Matched kind 'expression' of type `array of integer`
+   | 
+ 6 |     x = new int[2];
+   |         ^^^^^^^^^^
+
+info: Matched kind 'expression' of type `integer`
+   | 
+ 6 |     x = new int[2];
+   |                 ^
+
+info: Matched kind 'expression' of type `array of integer associated with field definition 'x'`
+   | 
+ 7 |     return x;
+   |            ^
+
+info: Matched kind 'expression' of type `integer associated with an array access`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |             ^^^^^^^^^^^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with method definition 'foo'`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |             ^^^^^^^^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                   ^
+
+info: Matched kind 'expression' of type `integer associated with an array access`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                      ^^^^^^^^^^^
+
+info: Matched kind 'expression' of type `array of integer associated with method definition 'foo'`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                      ^^^^^^^^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                            ^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 12 |     int x = m.foo(1)[m.foo(2)[1]];
+    |                               ^
+
+info: Matched kind 'expression' of type `boolean`
+    | 
+ 14 |     if (x > 1) {
+    |         ^^^^^
+
+info: Matched kind 'expression' of type `integer associated with local variable definition 'x'`
+    | 
+ 14 |     if (x > 1) {
+    |         ^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 14 |     if (x > 1) {
+    |             ^
+
+info: Matched kind 'expression' of type `integer`
+    | 
+ 15 |         System.out.println(12);
+    |                            ^^
+

--- a/runner-integration-tests/README.md
+++ b/runner-integration-tests/README.md
@@ -1,37 +1,42 @@
-|--------------|-------------------------------------------------|----------------------|
-| Folder       | Description                                     | Cli Equivalent       |
-|--------------|-------------------------------------------------|----------------------|
-| lexer        | Assert stdin/stdout/exitcode of the lexer       | `--lextest`          |
-|--------------|-------------------------------------------------|----------------------|
-| parser       | Assert stdin/stdout/exitcode of parser. Note    | `--parsetest`        |
-|              | that errors may change since the parser pulls   |                      |
-|              | the lexer.                                      |                      |
-|--------------|-------------------------------------------------|----------------------|
-| semantic     | Assert stderr/exitcode of a semanatic analysis. | `--check`            |
-|              | stdout should always be empty.                  |                      |
-|--------------|-------------------------------------------------|----------------------|
-| ast          | Same as semantic analysis, but prints           |                      |
-|              | normalized MiniJava on stdout. Normalized       |                      |
-|              | MiniJava is feed into the compiler and checked  |                      |
-|              | for idempotency.                                |                      |
-|--------------|-------------------------------------------------|----------------------|
-| assembly     | Assert stderr/stdout/exitcode and the generated | `--lower --emit-asm` |
-|              | assembly file.                                  |                      |
-|--------------|-------------------------------------------------|----------------------|
-| binary       | Assert stderr/stdout/exitcode for binary        |                      |
-|              | generation (a full compiler call). Run the      |                      |
-|              | generated binary and assert stderr/stdout       |                      |
-|              | and exitcode.                                   |                      |
-|--------------|-------------------------------------------------|----------------------|
-| timeout      | Assert stderr/stdout/exitcode for binary        |                      |
-|              | generation (a full compiler call). Run the      |                      |
-|              | generated binary and assert that it does never  |                      |
-|              | return.                                         |                      |
-|--------------|-------------------------------------------------|----------------------|
-| optimization | Compile the binary once with optimizations,     |                      |
-|              | once without optimizations. Assert that the     |                      |
-|              | emitted assembly changed/did not change/matches |                      |
-|              | the assembly of another program. Assert that    |                      |
-|              | the behaviour of the binary is identical to the |                      |
-|              | unoptimized binary.                             |                      |
-|--------------|-------------------------------------------------|----------------------|
+|--------------|-------------------------------------------------|----------------------------|
+| Folder       | Description                                     | Cli Equivalent             |
+|--------------|-------------------------------------------------|----------------------------|
+| lexer        | Assert stdin/stdout/exitcode of the lexer       | `--lextest`                |
+|--------------|-------------------------------------------------|----------------------------|
+| parser       | Assert stdin/stdout/exitcode of parser. Note    | `--parsetest`              |
+|              | that errors may change since the parser pulls   |                            |
+|              | the lexer.                                      |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| semantic     | Assert stderr/exitcode of a semanatic analysis. | `--check`                  |
+|              | stdout should always be empty.                  |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| ast          | Same as semantic analysis, but prints           |                            |
+|              | normalized MiniJava on stdout. Normalized       |                            |
+|              | MiniJava is feed into the compiler and checked  |                            |
+|              | for idempotency.                                |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| assembly     | Assert stderr/stdout/exitcode and the generated | `--lower --emit-asm`       |
+|              | assembly file.                                  |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| binary       | Assert stderr/stdout/exitcode for binary        |                            |
+|              | generation (a full compiler call). Run the      |                            |
+|              | generated binary and assert stderr/stdout       |                            |
+|              | and exitcode.                                   |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| timeout      | Assert stderr/stdout/exitcode for binary        |                            |
+|              | generation (a full compiler call). Run the      |                            |
+|              | generated binary and assert that it does never  |                            |
+|              | return.                                         |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| optimization | Compile the binary once with optimizations,     |                            |
+|              | once without optimizations. Assert that the     |                            |
+|              | emitted assembly changed/did not change/matches |                            |
+|              | the assembly of another program. Assert that    |                            |
+|              | the behaviour of the binary is identical to the |                            |
+|              | unoptimized binary.                             |                            |
+|--------------|-------------------------------------------------|----------------------------|
+| spans        | Assert information emitted by the command line  | `cargo run -p inspect-ast` |
+|              | utility `inspect-ast`. These tests verify       |                            |
+|              | generation of text spans in the parser and      |                            |
+|              | type information emitted by the type checker.   |                            |
+|--------------|-------------------------------------------------|----------------------------|

--- a/runner-integration-tests/src/lib.rs
+++ b/runner-integration-tests/src/lib.rs
@@ -40,7 +40,11 @@ pub enum CompilerPhase {
 #[allow(dead_code)]
 pub enum CompilerCall {
     RawCompiler(CompilerPhase),
-    AstInspector,
+    AstInspector {
+        content: Option<String>,
+        kind: Option<String>,
+        typeinfo: Option<String>,
+    },
 }
 
 /// Arguments that should be given to the compiler under test
@@ -106,7 +110,11 @@ fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command {
 
             cmd
         }
-        CompilerCall::AstInspector => {
+        CompilerCall::AstInspector {
+            content,
+            kind,
+            typeinfo,
+        } => {
             let ast_inspector_path = project_binary(Some("inspect-ast"));
             println!(
                 "Test run using the ast inspector binary at {:?}",
@@ -114,6 +122,18 @@ fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command {
             );
 
             let mut cmd = Command::new(ast_inspector_path);
+
+            if let Some(filter) = content {
+                cmd.args(&["-c", &filter]);
+            }
+
+            if let Some(filter) = kind {
+                cmd.args(&["-k", &filter]);
+            }
+
+            if let Some(filter) = typeinfo {
+                cmd.args(&["-t", &filter]);
+            }
 
             cmd.env("TERM", "dumb").arg(filepath.as_os_str());
 

--- a/runner-integration-tests/src/testkind/mod.rs
+++ b/runner-integration-tests/src/testkind/mod.rs
@@ -6,3 +6,6 @@ pub use self::timeout::*;
 
 mod optimization;
 pub use self::optimization::*;
+
+mod spans;
+pub use self::spans::*;

--- a/runner-integration-tests/src/testkind/spans.rs
+++ b/runner-integration-tests/src/testkind/spans.rs
@@ -1,0 +1,68 @@
+use crate::*;
+use serde_derive::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Data {
+    pub stderr: Option<ExpectedData>,
+    pub stdout: Option<ExpectedData>,
+    pub exitcode: Option<ExpectedData>,
+    pub content: Option<String>,
+    pub kind: Option<String>,
+    pub typeinfo: Option<String>,
+}
+
+impl FromReferencesPath<Data> for Data {
+    fn from_reference_path(_base: &PathBuf) -> Self {
+        Self::default()
+    }
+}
+
+impl IntoReferenceData for Data {
+    fn into_reference_data(self, base: &PathBuf) -> ReferenceData {
+        self.into_reference_data(base)
+    }
+}
+
+impl Data {
+    fn into_reference_data(self, base: &PathBuf) -> ReferenceData {
+        ReferenceData {
+            stderr: self
+                .stderr
+                .unwrap_or_else(|| ExpectedData::Inline("".to_owned())),
+            stdout: self
+                .stdout
+                .unwrap_or_else(|| default_reference_stdout(&base)),
+            exitcode: self
+                .exitcode
+                .unwrap_or_else(|| ExpectedData::Inline("0".to_owned())),
+        }
+    }
+}
+
+pub fn exec_ast_inspector_test(input: PathBuf) {
+    let spec = TestSpec {
+        references: input.clone(),
+        input,
+        generate_tentatives: true,
+    };
+
+    let (input_without_yaml_path, data) = load_test_data::<Data>(&spec);
+
+    let callinfo = CompilerCall::AstInspector {
+        content: data.reference.content.clone(),
+        kind: data.reference.kind.clone(),
+        typeinfo: data.reference.typeinfo.clone(),
+    };
+
+    let mut call = compiler_call(callinfo, &input_without_yaml_path);
+    println!("Executing: {:?}", call);
+
+    let output = call.output().expect("failed to call ast-inspector");
+
+    assert_output(
+        &output,
+        data.reference.clone().into_reference_data(&spec.references),
+        &spec,
+    );
+}


### PR DESCRIPTION
- [x] Add Filter `-t`/`--expression-of-type` to `cargo run -p inspect-ast` that allows to filter AST nodes by type system information
- [x] Add dedicated yaml fields `typeinfo: REGEX`, `kind: REGEX`, `content: REGEX` to `span` tests. This means you can now create type system tests in the following format:
```java
---
kind: expression
typeinfo: bool
content: ">"
---
class ArrayAccessIsByValue {
  public int[] x;

  public int[] foo(int callsite) {
    System.out.println(callsite);
    x = new int[2];
    return x;
  }

  public static void main(String[] args) {
    ArrayAccessIsByValue m = new ArrayAccessIsByValue();
    int x = m.foo(1)[m.foo(2)[1]];
    
    if (x > 1) {
        System.out.println(12);
    }
  }
}
```
This example match any expression of type boolean that uses a '>' comparison. Which will print:
```
info: Matched kind 'expression' of type `boolean`
    | 
 14 |     if (x > 1) {
    |         ^^^^^
```