### PR TITLE
Compiler Internal Timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
  "rocket_contrib 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "streaming-stats 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1268,9 +1270,11 @@ version = "0.1.0"
 dependencies = [
  "compiler-lib 0.0.1",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "integration_test_codegen 0.0.1",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-humantime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1407,6 +1411,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "state"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "streaming-stats"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -1958,6 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
+"checksum streaming-stats 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fd8abbec7f4bc18e9e761572465226e63f88c1cb90ee8b3f403a81631ef9fd50"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,6 @@ dependencies = [
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "streaming-stats 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1272,15 +1271,16 @@ dependencies = [
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "integration_test_codegen 0.0.1",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-humantime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "streaming-stats 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1338,15 +1338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde-humantime"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde_derive"
@@ -1961,7 +1952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
-"checksum serde-humantime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c367b5dafa12cef19c554638db10acde90d5e9acea2b80e1ad98b00f88068f7d"
 "checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,7 @@ dependencies = [
 name = "runner-integration-tests"
 version = "0.1.0"
 dependencies = [
+ "compiler-cli 0.0.1",
  "compiler-lib 0.0.1",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -77,6 +77,52 @@ in the `/compiler-cli/.tmpIR/` folder. (But note that if you are testing the
 compiler directly by using `cargo run` instead of `cargo test`, VCG files are
 generated in `.tmpIR/` in the root of the repository.)
 
+## Benchmarking
+
+The compiler has an internal timer that can be used to benchmark each compiler
+phase.  You could get an excerpt for a single run using the env flag
+`MEASURE_STDERR=yes` or `MEASURE_JSON=FILE.json`. But please use the benchmark
+utility instead. Invoking
+
+```
+cargo run --bin benchmark
+```
+
+will benchmark all mjtests in the `tests/big` folder and print a listing in the
+following format:
+
+```
+BENCHMARK bench_conways_game_of_life.input
+==========================================
+
+optimization phase                680.66667 +/- 14.38363ms    3 samples      -0.681%     1m 9s ago
+  opt #0: Inline                  113.00000 +/-  3.55903ms    3 samples      -3.966%     1m 9s ago
+  opt #1: ConstantFolding         449.00000 +/-  9.20145ms    3 samples      +0.074%     1m 9s ago
+  opt #2: ControlFlow             117.33333 +/-  1.24722ms    3 samples      -0.283%     1m 9s ago
+
+
+BENCHMARK bench_math.input
+==========================
+
+optimization phase               2590.33333 +/- 26.02990ms    3 samples      -3.177%     1m 9s ago
+  opt #0: Inline                  438.66667 +/-  6.84755ms    3 samples      -0.529%     1m 9s ago
+  opt #1: ConstantFolding        1388.00000 +/-  6.68331ms    3 samples      -6.385%     1m 9s ago
+  opt #2: ControlFlow             762.33333 +/- 18.51726ms    3 samples      +1.554%     1m 9s ago
+```
+
+The percentage and relative time, e.g. `-0.681% 1m 9s ago`, are a comparison to the last invokation
+of the benchmark utility, e.g. `0.681%` faster to the invokation 1 minute and 9 seconds ago.
+
+The benchmark utility accepts some flags (that are more thoroughly explained in its `--help` dialog):
+
+```
+cargo run --bin benchmark -- --samples NUM_SAMPLES --only REGEX --optimization Aggressive|None|Moderate|Custom:*
+```
+
+`--samples` specifies the number of invokations per input file. `--only` is a regex that can be used to
+filter the input files, e.g. `math|conway` will only run the benchmarks shown in the example output above.
+`--optimization` is identicial to the `--optimization` flag that the compiler-cli accepts.
+
 
 ## Tools
 

--- a/compiler-cli/src/lib.rs
+++ b/compiler-cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod optimization_arg;

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -220,6 +220,8 @@ fn main() {
     if let Err(msg) = run_compiler(&cmd) {
         exit_with_error(&msg);
     }
+
+    compiler_lib::timing::print();
 }
 
 use env_logger::{

--- a/compiler-lib/Cargo.toml
+++ b/compiler-lib/Cargo.toml
@@ -33,9 +33,6 @@ rocket = "0.4.0"
 rocket_contrib = "0.4.0"
 lazy_static = "1.2.0"
 
-# for benchmarking
-streaming-stats = "0.2"
-
 [dev-dependencies]
 mjtest = { path = "../mjtest-rs" }
 mjtest_macros = { path = "../mjtest-rs/mjtest_macros" }

--- a/compiler-lib/Cargo.toml
+++ b/compiler-lib/Cargo.toml
@@ -24,6 +24,7 @@ libc = "0.2"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 priority-queue = "0.5.2"
 petgraph = "0.4.13"
 
@@ -31,6 +32,9 @@ petgraph = "0.4.13"
 rocket = "0.4.0"
 rocket_contrib = "0.4.0"
 lazy_static = "1.2.0"
+
+# for benchmarking
+streaming-stats = "0.2"
 
 [dev-dependencies]
 mjtest = { path = "../mjtest-rs" }

--- a/compiler-lib/src/lib.rs
+++ b/compiler-lib/src/lib.rs
@@ -15,11 +15,13 @@
 #![feature(result_map_or_else)]
 #![feature(proc_macro_hygiene, decl_macro)]
 #![feature(try_trait)]
+#![feature(duration_as_u128)]
 #[macro_use]
 extern crate derive_more;
 
 mod analysis;
 pub mod asciifile;
+pub mod timing;
 #[macro_use]
 mod utils;
 pub mod ast;

--- a/compiler-lib/src/optimization/mod.rs
+++ b/compiler-lib/src/optimization/mod.rs
@@ -1,4 +1,4 @@
-use crate::firm::FirmProgram;
+use crate::{firm::FirmProgram, timing::Measurement};
 use libfirm_rs::{bindings, Graph};
 use std::ffi::CString;
 
@@ -192,7 +192,9 @@ impl Level {
 
         for (i, optimization) in self.sequence().iter().enumerate() {
             log::info!("Running optimization #{}: {:?}", i, optimization);
+            let measurement = Measurement::start(&format!("opt #{}: {}", i, optimization.kind));
             optimization.run(program);
+            measurement.stop();
             log::debug!("Finished optimization #{}: {:?}", i, optimization.kind);
         }
 

--- a/compiler-lib/src/optimization/mod.rs
+++ b/compiler-lib/src/optimization/mod.rs
@@ -189,6 +189,7 @@ impl Level {
     /// on the given program
     pub fn run_all(&self, program: &FirmProgram<'_, '_>) {
         breakpoint!("before optimization sequence".to_string(), program);
+        let measurement_all = Measurement::start("optimization phase");
 
         for (i, optimization) in self.sequence().iter().enumerate() {
             log::info!("Running optimization #{}: {:?}", i, optimization);
@@ -197,6 +198,8 @@ impl Level {
             measurement.stop();
             log::debug!("Finished optimization #{}: {:?}", i, optimization.kind);
         }
+
+        measurement_all.stop();
 
         breakpoint!("after optimization sequence".to_string(), program);
     }

--- a/compiler-lib/src/timing.rs
+++ b/compiler-lib/src/timing.rs
@@ -1,0 +1,87 @@
+//! Measures time taken by single phases of the compiler.
+//!
+//! This is especially useful to detect problems in optimization
+//! routines.
+//!
+//! This is NOT an utility that should be used for benchmarking!
+//! Benchmarking involves running a program multiple times with
+//! warm up phases and median/avg/stddev of measurements.
+
+use std::{
+    fmt,
+    sync::Mutex,
+    time::{Duration, Instant},
+}; // TODO: more precise clock
+
+lazy_static::lazy_static! {
+    static ref TIMINGS: Mutex<Timings> = { Mutex::new(Timings { measurements: Vec::new()}) };
+}
+
+pub struct Measurement {
+    start: Instant,
+    label: String,
+}
+
+impl Measurement {
+    pub fn start(label: &str) -> Measurement {
+        Self {
+            start: Instant::now(),
+            label: label.to_string(),
+        }
+    }
+
+    pub fn stop(self) {
+        let measurement = CompletedMeasurement {
+            label: self.label,
+            start: self.start,
+            stop: Instant::now(),
+        };
+        TIMINGS.lock().unwrap().measurements.push(measurement);
+    }
+}
+
+struct Timings {
+    measurements: Vec<CompletedMeasurement>,
+}
+
+impl fmt::Display for Timings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Performance Analysis")?;
+        writeln!(f, "====================\n")?;
+
+        if cfg!(feature = "debugger_gui") {
+            writeln!(f, "Measurements not available with enabled breakpoints")?;
+        } else {
+            let min_label_width = 50;
+
+            for timing in &self.measurements {
+                writeln!(
+                    f,
+                    "{: <label_width$}    {: >ms_width$}ms",
+                    timing.label,
+                    timing.duration().as_millis(),
+                    label_width = min_label_width,
+                    ms_width = 6
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct CompletedMeasurement {
+    start: Instant,
+    stop: Instant,
+    label: String,
+}
+
+impl CompletedMeasurement {
+    fn duration(&self) -> Duration {
+        self.stop.duration_since(self.start)
+    }
+}
+
+pub fn print() {
+    eprintln!("{}", TIMINGS.lock().unwrap());
+}

--- a/compiler-lib/src/timing.rs
+++ b/compiler-lib/src/timing.rs
@@ -9,9 +9,12 @@
 
 use std::{
     fmt,
+    fs::File,
     sync::Mutex,
     time::{Duration, Instant},
 }; // TODO: more precise clock
+
+use stats::OnlineStats;
 
 lazy_static::lazy_static! {
     static ref TIMINGS: Mutex<Timings> = { Mutex::new(Timings { measurements: Vec::new()}) };
@@ -42,41 +45,6 @@ impl Measurement {
 }
 
 #[derive(Debug, Clone)]
-struct Timings {
-    measurements: Vec<CompletedMeasurement>,
-}
-
-impl fmt::Display for Timings {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let min_label_width = 50;
-
-        let mut active = vec![];
-
-        let mut listing = self.measurements.clone();
-        listing.sort_by(|a, b| a.start.cmp(&b.start));
-
-        for timing in listing.into_iter() {
-            active.retain(|measurement: &CompletedMeasurement| measurement.stop > timing.start);
-
-            let indent = "  ".repeat(active.len());
-            writeln!(
-                f,
-                "{nesting}{: <label_width$}    {: >ms_width$}ms",
-                timing.label,
-                timing.duration().as_millis(),
-                nesting = indent,
-                label_width = min_label_width - indent.len(),
-                ms_width = 6
-            )?;
-
-            active.push(timing);
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
 struct CompletedMeasurement {
     start: Instant,
     stop: Instant,
@@ -89,8 +57,41 @@ impl CompletedMeasurement {
     }
 }
 
+#[derive(Debug, Clone)]
+struct Timings {
+    measurements: Vec<CompletedMeasurement>,
+}
+
+impl fmt::Display for Timings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        AsciiDisp(&CompilerMeasurements::from(self.clone())).fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for AsciiDisp<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let min_label_width = 50;
+
+        for timing in self.0 {
+            let indent = "  ".repeat(timing.indent);
+
+            writeln!(
+                f,
+                "{nesting}{: <label_width$}    {: >ms_width$}ms",
+                timing.label,
+                timing.duration.as_millis(),
+                nesting = indent,
+                label_width = min_label_width - indent.len(),
+                ms_width = 6
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
 pub fn print() {
-    if std::env::var("MEASURE").is_ok() {
+    if std::env::var("MEASURE_STDERR").is_ok() {
         eprintln!("Performance Analysis");
         eprintln!("====================\n");
 
@@ -99,5 +100,128 @@ pub fn print() {
         } else {
             eprintln!("{}", TIMINGS.lock().unwrap());
         }
+    }
+
+    if let Ok(path) = std::env::var("MEASURE_JSON") {
+        let file = File::create(path).unwrap();
+        serde_json::to_writer(
+            file,
+            &CompilerMeasurements::from(TIMINGS.lock().unwrap().clone()),
+        )
+        .unwrap();
+    }
+}
+
+// Frozen and completed measurements that can be serialized
+pub type CompilerMeasurements = Vec<SingleMeasurement>;
+pub struct AsciiDisp<'a>(pub &'a CompilerMeasurements);
+
+impl From<Timings> for CompilerMeasurements {
+    fn from(measurements: Timings) -> Self {
+        let mut frozen = vec![];
+        let mut active = vec![];
+
+        let mut listing = measurements.measurements.clone();
+        listing.sort_by(|a, b| a.start.cmp(&b.start));
+
+        for timing in listing.into_iter() {
+            active.retain(|measurement: &CompletedMeasurement| measurement.stop > timing.start);
+
+            frozen.push(SingleMeasurement {
+                label: timing.label.clone(),
+                indent: active.len(),
+                duration: timing.duration(),
+            });
+
+            active.push(timing);
+        }
+
+        frozen
+    }
+}
+
+#[derive(Debug, Clone, serde_derive::Serialize, serde_derive::Deserialize)]
+pub struct SingleMeasurement {
+    label: String,
+    indent: usize,
+    duration: Duration,
+}
+
+//
+#[derive(Debug, Clone)]
+pub struct BenchmarkEntry {
+    label: String,
+    indent: usize,
+    stats: OnlineStats,
+}
+
+pub struct Benchmark {
+    measurements: Vec<BenchmarkEntry>,
+}
+
+impl Benchmark {
+    pub fn new() -> Self {
+        Self {
+            measurements: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, measurements: &[SingleMeasurement]) {
+        if self.measurements.len() == 0 {
+            for measurement in measurements {
+                self.measurements.push(BenchmarkEntry {
+                    label: measurement.label.clone(),
+                    indent: measurement.indent,
+                    stats: OnlineStats::from_slice(&[measurement.duration.as_millis()]),
+                });
+            }
+            return;
+        }
+
+        if !self.is_compatible(measurements) {
+            panic!("measurements incomplete");
+        }
+
+        for (i, item) in measurements.iter().enumerate() {
+            self.measurements[i].stats.add(item.duration.as_millis());
+        }
+    }
+
+    fn is_compatible(&self, measurements: &[SingleMeasurement]) -> bool {
+        if measurements.len() != self.measurements.len() {
+            return false;
+        }
+
+        for (this, other) in self.measurements.iter().zip(measurements.iter()) {
+            if this.label != other.label || this.indent != other.indent {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl fmt::Display for Benchmark {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let min_label_width = 50;
+
+        for timing in &self.measurements {
+            let indent = "  ".repeat(timing.indent);
+            writeln!(
+                f,
+                "{nesting}{label: <label_width$}    {ms: >ms_width$.5} +/- {stddev: >stddev_width$.5}ms    {samples} samples",
+                label  = timing.label,
+                ms = timing.stats.mean(),
+                stddev = timing.stats.stddev(),
+                samples = timing.stats.len(),
+                nesting = indent,
+                label_width = min_label_width - indent.len(),
+                ms_width = 20,
+                stddev_width = 10
+            )?;
+        }
+
+        Ok(())
     }
 }

--- a/compiler-lib/src/timing.rs
+++ b/compiler-lib/src/timing.rs
@@ -14,8 +14,6 @@ use std::{
     time::{Duration, Instant},
 }; // TODO: more precise clock
 
-use stats::OnlineStats;
-
 lazy_static::lazy_static! {
     static ref TIMINGS: Mutex<Timings> = { Mutex::new(Timings { measurements: Vec::new()}) };
 }
@@ -142,86 +140,7 @@ impl From<Timings> for CompilerMeasurements {
 
 #[derive(Debug, Clone, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct SingleMeasurement {
-    label: String,
-    indent: usize,
-    duration: Duration,
-}
-
-//
-#[derive(Debug, Clone)]
-pub struct BenchmarkEntry {
-    label: String,
-    indent: usize,
-    stats: OnlineStats,
-}
-
-pub struct Benchmark {
-    measurements: Vec<BenchmarkEntry>,
-}
-
-impl Benchmark {
-    pub fn new() -> Self {
-        Self {
-            measurements: Vec::new(),
-        }
-    }
-
-    pub fn add(&mut self, measurements: &[SingleMeasurement]) {
-        if self.measurements.len() == 0 {
-            for measurement in measurements {
-                self.measurements.push(BenchmarkEntry {
-                    label: measurement.label.clone(),
-                    indent: measurement.indent,
-                    stats: OnlineStats::from_slice(&[measurement.duration.as_millis()]),
-                });
-            }
-            return;
-        }
-
-        if !self.is_compatible(measurements) {
-            panic!("measurements incomplete");
-        }
-
-        for (i, item) in measurements.iter().enumerate() {
-            self.measurements[i].stats.add(item.duration.as_millis());
-        }
-    }
-
-    fn is_compatible(&self, measurements: &[SingleMeasurement]) -> bool {
-        if measurements.len() != self.measurements.len() {
-            return false;
-        }
-
-        for (this, other) in self.measurements.iter().zip(measurements.iter()) {
-            if this.label != other.label || this.indent != other.indent {
-                return false;
-            }
-        }
-
-        true
-    }
-}
-
-impl fmt::Display for Benchmark {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let min_label_width = 50;
-
-        for timing in &self.measurements {
-            let indent = "  ".repeat(timing.indent);
-            writeln!(
-                f,
-                "{nesting}{label: <label_width$}    {ms: >ms_width$.5} +/- {stddev: >stddev_width$.5}ms    {samples} samples",
-                label  = timing.label,
-                ms = timing.stats.mean(),
-                stddev = timing.stats.stddev(),
-                samples = timing.stats.len(),
-                nesting = indent,
-                label_width = min_label_width - indent.len(),
-                ms_width = 20,
-                stddev_width = 10
-            )?;
-        }
-
-        Ok(())
-    }
+    pub label: String,
+    pub indent: usize,
+    pub duration: Duration,
 }

--- a/runner-integration-tests/Cargo.toml
+++ b/runner-integration-tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 integration_test_codegen = { path = "../codegen-integration-tests" }
 compiler-lib = { path = "../compiler-lib" }
+compiler-cli = { path = "../compiler-cli" }
 difference = "2.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/runner-integration-tests/Cargo.toml
+++ b/runner-integration-tests/Cargo.toml
@@ -19,3 +19,5 @@ failure = "0.1"
 regex = "1"
 # used to parse Duration from a string in the YAML of timeout tests
 serde-humantime = "0.1.1"
+log = "0.4"
+env_logger = "0.6"

--- a/runner-integration-tests/Cargo.toml
+++ b/runner-integration-tests/Cargo.toml
@@ -17,7 +17,9 @@ wait-timeout = "0.1.5"
 structopt = "0.2"
 failure = "0.1"
 regex = "1"
-# used to parse Duration from a string in the YAML of timeout tests
-serde-humantime = "0.1.1"
 log = "0.4"
 env_logger = "0.6"
+
+# for benchmarking
+streaming-stats = "0.2"
+humantime = "1.2.0"

--- a/runner-integration-tests/src/bin/benchmark.rs
+++ b/runner-integration-tests/src/bin/benchmark.rs
@@ -1,0 +1,112 @@
+//! Executes all mjtests in the /exec/big folder.
+use compiler_lib::timing::{AsciiDisp, Benchmark, CompilerMeasurements};
+use runner_integration_tests::{compiler_call, CompilerCall, CompilerPhase};
+use std::{
+    ffi::OsStr,
+    fs::{self, File},
+    io::BufReader,
+    path::PathBuf,
+};
+
+fn test_folder() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../mjtest-rs/tests")
+}
+
+#[derive(Debug, Clone)]
+struct BigTest {
+    minijava: PathBuf,
+    stdin: Option<PathBuf>,
+}
+
+fn big_tests() -> Vec<BigTest> {
+    let dirpath = test_folder().join("exec/big");
+    log::info!("test directory is {}", dirpath.display());
+    let dirlisting = fs::read_dir(dirpath).unwrap();
+
+    let mut big_tests = vec![];
+
+    for entry in dirlisting {
+        let path = entry.unwrap().path();
+        if path.extension() == Some(OsStr::new("java")) {
+            let test = BigTest {
+                stdin: {
+                    let mut stdin = path.clone();
+                    let stem = path.file_stem().unwrap();
+                    // remove extension
+                    stdin.pop();
+                    stdin.push(stem);
+                    // set new extension
+                    stdin.set_extension("inputc");
+                    log::debug!("looking for stdin file at {}", stdin.display());
+                    if stdin.is_file() {
+                        Some(stdin)
+                    } else {
+                        None
+                    }
+                },
+                minijava: path,
+            };
+
+            log::debug!("Found test: {:?}", test);
+
+            big_tests.push(test);
+        }
+    }
+
+    big_tests
+}
+
+fn profile_compiler(test: &BigTest) -> CompilerMeasurements {
+    let mut cmd = compiler_call(
+        CompilerCall::RawCompiler(CompilerPhase::Binary {
+            // TODO: use temp dir, don't trash
+            output: test.minijava.with_extension("out"),
+            assembly: None,
+            optimizations: compiler_lib::optimization::Level::Aggressive,
+        }),
+        &test.minijava,
+    );
+
+    let measurement_path = "measurement.json";
+
+    cmd.env("MEASURE_JSON", measurement_path);
+
+    // TODO: run and benchmark the binary
+    //if let Some(stdin_path) = test.stdin {
+    //cmd.stdin(Stdio::piped());
+    //let mut stdin_reader = File::open(&stdin_path).expect("failed to open stdin
+    // file"); io::copy(&mut stdin_reader, stdin)
+    //.expect("failed to write to stdin of binary");
+    //}
+
+    log::debug!("calling compiler as: {:?}", cmd);
+    cmd.status().expect("failed to compile test");
+
+    let stats_file = File::open(measurement_path).unwrap();
+    let stats_reader = BufReader::new(stats_file);
+    let profile = serde_json::from_reader(stats_reader).unwrap();
+    log::debug!("Stats:\n{}", AsciiDisp(&profile));
+    profile
+}
+
+fn main() {
+    env_logger::init();
+
+    let times = 2;
+
+    for big_test in &big_tests() {
+        let mut bench = Benchmark::new();
+        for _ in 0..times {
+            let timings = profile_compiler(big_test);
+            bench.add(&timings);
+        }
+
+        let title = format!(
+            "BENCHMARK {}",
+            big_test.minijava.file_stem().unwrap().to_string_lossy()
+        );
+
+        println!("{}\n{}\n", title, "=".repeat(title.len()));
+        println!("{}\n", bench);
+    }
+}

--- a/runner-integration-tests/src/bin/benchmark.rs
+++ b/runner-integration-tests/src/bin/benchmark.rs
@@ -66,7 +66,7 @@ fn big_tests() -> Vec<BigTest> {
 
 fn profile_compiler(test: &BigTest) -> Option<CompilerMeasurements> {
     let mut cmd = compiler_call(
-        CompilerCall::RawCompiler(CompilerPhase::Binary {
+        CompilerCall::RawCompiler(CompilerPhase::BinaryLibfirm {
             // TODO: use temp dir, don't trash
             output: test.minijava.with_extension("out"),
             assembly: None,
@@ -196,7 +196,7 @@ impl Benchmark {
     }
 
     pub fn add(&mut self, measurements: &[SingleMeasurement]) {
-        if self.measurements.len() == 0 {
+        if self.measurements.is_empty() {
             for measurement in measurements {
                 self.measurements.push(BenchmarkEntry {
                     label: measurement.label.clone(),
@@ -243,7 +243,7 @@ impl Benchmark {
                 measurement.label.clone(),
                 ReferenceBenchmark {
                     mean: measurement.stats.mean(),
-                    timestamp: now.clone(),
+                    timestamp: now,
                 },
             );
         }

--- a/runner-integration-tests/src/lib.rs
+++ b/runner-integration-tests/src/lib.rs
@@ -101,12 +101,12 @@ pub fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command
         CompilerCall::RawCompiler(phase) => {
             let mut cmd = env::var("COMPILER_BINARY")
                 .map(|path| {
-                    println!("Test run using alternate compiler binary at {}", path);
+                    log::debug!("Test run using alternate compiler binary at {}", path);
                     Command::new(path)
                 })
                 .unwrap_or_else(|_| {
                     let binary = project_binary(Some("compiler-cli"));
-                    println!("Test run using the default compiler binary at {:?}", binary);
+                    log::debug!("Test run using the default compiler binary at {:?}", binary);
                     Command::new(binary)
                 });
 

--- a/runner-integration-tests/src/lib.rs
+++ b/runner-integration-tests/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(nll)]
 
 pub mod lookup;
+pub mod serde_humantime;
 mod testkind;
 pub mod yaml;
 pub use self::{lookup::*, testkind::*};

--- a/runner-integration-tests/src/lib.rs
+++ b/runner-integration-tests/src/lib.rs
@@ -96,7 +96,7 @@ fn compiler_args(phase: CompilerPhase) -> Vec<OsString> {
     args.iter().map(OsString::from).collect::<Vec<_>>()
 }
 
-fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command {
+pub fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command {
     match compiler_call {
         CompilerCall::RawCompiler(phase) => {
             let mut cmd = env::var("COMPILER_BINARY")

--- a/runner-integration-tests/src/serde_humantime.rs
+++ b/runner-integration-tests/src/serde_humantime.rs
@@ -1,0 +1,64 @@
+use serde::de::{Deserialize, Deserializer, Error, Unexpected, Visitor};
+use std::{fmt, time::Duration};
+
+/// A wrapper type which implements `Deserialize` for types involving
+/// `Duration`.
+///
+/// It can only be constructed through its `Deserialize` implementations.
+pub struct De<T>(T);
+
+impl<T> De<T> {
+    /// Consumes the `De`, returning the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Duration> {
+    fn deserialize<D>(d: D) -> Result<De<Duration>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(d).map(De)
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Option<Duration>> {
+    fn deserialize<D>(d: D) -> Result<De<Option<Duration>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Option::<De<Duration>>::deserialize(d)? {
+            Some(De(dur)) => Ok(De(Some(dur))),
+            None => Ok(De(None)),
+        }
+    }
+}
+
+/// Deserializes a `Duration` via the humantime crate.
+///
+/// This function can be used with `serde_derive`'s `with` and
+/// `deserialize_with` annotations.
+pub fn deserialize<'de, D>(d: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct V;
+
+    impl<'de2> Visitor<'de2> for V {
+        type Value = Duration;
+
+        fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            fmt.write_str("a duration")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Duration, E>
+        where
+            E: Error,
+        {
+            humantime::parse_duration(v).map_err(|_| E::invalid_value(Unexpected::Str(v), &self))
+        }
+    }
+
+    d.deserialize_str(V)
+}


### PR DESCRIPTION
- Adds a compiler internal timer
- Adds a benchmark utility automatically running all 'big' mjtests

# Internal Timer
API is:

```rust
let measurement = Measurement::start("label");
// do stuff, e.g. sleep(2), then:
measurement.stop();
```
You could get an excerpt for a single run using the env flags `MEASURE_STDERR=yes` and `MEASURE_JSON=file.json`. But please use the benchmark utility instead.

Output looks like:
```
Performance Analysis
====================

optimization phase                                        49ms
  opt #0: Inline                                           5ms
  opt #1: ConstantFolding                                 37ms
  opt #2: ControlFlow                                      5ms
```

# Benchmark Utility

```
cargo run --bin benchmark
```

gives

```
BENCHMARK bench_conways_game_of_life.input
==========================================

optimization phase                                             12959.00000 +/-  988.00000ms    2 samples
  opt #0: Inline                                                3332.00000 +/-   48.00000ms    2 samples
  opt #1: ConstantFolding                                       8424.50000 +/-  940.50000ms    2 samples
  opt #2: ControlFlow                                           1201.50000 +/-    0.50000ms    2 samples


BENCHMARK bench_math.input
==========================

optimization phase                                             11971.00000 +/-    0.00000ms    2 samples
  opt #0: Inline                                                3284.00000 +/-    0.00000ms    2 samples
  opt #1: ConstantFolding                                       7484.00000 +/-    0.00000ms    2 samples
  opt #2: ControlFlow                                           1201.00000 +/-    0.00000ms    2 samples


BENCHMARK bench_BigTensorProduct.input
======================================

optimization phase                                              8569.50000 +/-   23.50000ms    2 samples
  opt #0: Inline                                                2367.00000 +/-    9.00000ms    2 samples
  opt #1: ConstantFolding                                       5678.50000 +/-   34.50000ms    2 samples
  opt #2: ControlFlow                                            522.50000 +/-    1.50000ms    2 samples


BENCHMARK bench_binarytrees
===========================

optimization phase                                              2408.00000 +/-  166.00000ms    2 samples
  opt #0: Inline                                                 716.00000 +/-   95.00000ms    2 samples
  opt #1: ConstantFolding                                       1444.50000 +/-   71.50000ms    2 samples
  opt #2: ControlFlow                                            247.00000 +/-    0.00000ms    2 samples


BENCHMARK bench_fannkuchredux
=============================

optimization phase                                              1260.50000 +/-    6.50000ms    2 samples
  opt #0: Inline                                                 229.00000 +/-    8.00000ms    2 samples
  opt #1: ConstantFolding                                        841.00000 +/-    3.00000ms    2 samples
  opt #2: ControlFlow                                            190.00000 +/-    2.00000ms    2 samples

```

It also supports some cli arguments:
```
cargo run --bin benchmark -- --samples USIZE --only REGEX --optimization Aggressive|None|Moderate|Custom:*
```