### PR TITLE
firm: support runtimes with different rt func names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ install: |
         pip install typing --user && \
         git clone https://git.scc.kit.edu/IPDSnelting/mjtest.git && \
         cd mjtest && \
-        git submodule update --init && \
-        git submodule update --remote && \
+        git submodule update --init --remote && \
         cd -;
         ;;
       submission-system)

--- a/compiler-lib/src/firm/firm_program.rs
+++ b/compiler-lib/src/firm/firm_program.rs
@@ -1,5 +1,6 @@
 use super::type_translation::*;
 use crate::{
+    firm::runtime::Runtime,
     ref_eq::RefEq,
     type_checking::type_system::{
         ClassDef, ClassFieldDef, ClassMethodBody, ClassMethodDef, TypeSystem,
@@ -37,6 +38,7 @@ pub struct FirmProgram<'src, 'ast> {
     pub fields: HashMap<RefEq<Rc<ClassFieldDef<'src>>>, FirmFieldP<'src, 'ast>>,
     pub methods: HashMap<RefEq<Rc<ClassMethodDef<'src, 'ast>>>, FirmMethodP<'src, 'ast>>,
     pub entities: HashMap<Entity, FirmEntity<'src, 'ast>>,
+    pub runtime: Rc<Runtime>,
 }
 
 pub type FirmClassP<'src, 'ast> = Rc<RefCell<FirmClass<'src, 'ast>>>;
@@ -62,12 +64,16 @@ pub struct FirmMethod<'src, 'ast> {
 }
 
 impl<'src, 'ast> FirmProgram<'src, 'ast> {
-    pub fn new(type_system: &'src TypeSystem<'src, 'ast>) -> FirmProgram<'src, 'ast> {
+    pub fn new(
+        type_system: &'src TypeSystem<'src, 'ast>,
+        runtime: Rc<Runtime>,
+    ) -> FirmProgram<'src, 'ast> {
         let mut program = FirmProgram {
             classes: HashMap::new(),
             fields: HashMap::new(),
             methods: HashMap::new(),
             entities: HashMap::new(),
+            runtime,
         };
         program.add_type_system(type_system);
         program
@@ -152,7 +158,7 @@ impl<'src, 'ast> FirmProgram<'src, 'ast> {
         let method_type = method_ty_builder.build(!method.is_main);
 
         let method_name = if method.is_main {
-            "mj_main".to_owned()
+            self.runtime.lib.mj_main_name().to_owned()
         } else {
             format!("{}.M.{}", class.borrow().def.name, method.name)
         };

--- a/compiler-lib/src/firm/mod.rs
+++ b/compiler-lib/src/firm/mod.rs
@@ -81,7 +81,8 @@ pub unsafe fn build<'src, 'ast>(
 ) -> Result<(), Error> {
     setup();
 
-    let generator = ProgramGenerator::new(type_system, type_analysis, strtab);
+    let rt = std::rc::Rc::new(Runtime::new(box runtime::Mjrt)); // FIXME constant
+    let generator = ProgramGenerator::new(rt, type_system, type_analysis, strtab);
     let program = generator.generate();
     if !opts.dump_folder.exists() {
         fs::create_dir_all(&opts.dump_folder).expect("Failed to create output directory");

--- a/compiler-lib/src/firm/program_generator.rs
+++ b/compiler-lib/src/firm/program_generator.rs
@@ -1,4 +1,4 @@
-use super::{firm_program::*, MethodBodyGenerator, Runtime};
+use super::{firm_program::*, runtime::Runtime, MethodBodyGenerator};
 use crate::{
     ast,
     strtab::StringTable,
@@ -13,7 +13,7 @@ use log;
 use std::rc::Rc;
 
 pub struct ProgramGenerator<'src, 'ast> {
-    runtime: Runtime,
+    runtime: Rc<Runtime>,
     type_system: &'src TypeSystem<'src, 'ast>,
     type_analysis: &'src TypeAnalysis<'src, 'ast>,
     strtab: &'src mut StringTable<'src>,
@@ -21,12 +21,13 @@ pub struct ProgramGenerator<'src, 'ast> {
 
 impl<'src, 'ast> ProgramGenerator<'src, 'ast> {
     pub fn new(
+        runtime: Rc<Runtime>,
         type_system: &'src TypeSystem<'src, 'ast>,
         type_analysis: &'src TypeAnalysis<'src, 'ast>,
         strtab: &'src mut StringTable<'src>,
     ) -> Self {
         Self {
-            runtime: Runtime::new(),
+            runtime,
             type_system,
             type_analysis,
             strtab,
@@ -34,7 +35,7 @@ impl<'src, 'ast> ProgramGenerator<'src, 'ast> {
     }
 
     pub fn generate(mut self) -> FirmProgram<'src, 'ast> {
-        let program = FirmProgram::new(self.type_system);
+        let program = FirmProgram::new(self.type_system, Rc::clone(&self.runtime));
 
         for method in program.methods.values() {
             log::debug!("generate method body for {:?}", method.borrow().def.name);


### PR DESCRIPTION
This is cherry-pick of a commit in the lowering WIP branch.
The conflicts were only in the lowering modules
(which are obviously non-existend in this branch)