### PR TITLE
cli/firm: refactor: compilation steps + multiple backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "inspect-ast 0.1.0",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfirm-rs 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mjrt 0.1.0",

--- a/compiler-cli/Cargo.toml
+++ b/compiler-cli/Cargo.toml
@@ -25,6 +25,7 @@ memmap = "0.7.0"
 libc = "*"
 termcolor = "1.0.4"
 compiler-lib = { path = "../compiler-lib" }
+libfirm-rs = { path = "../libfirm-rs" }
 inspect-ast = { path = "../inspect-ast" }
 tempfile = "3.0"
 mjrt = { path = "../mjrt" }

--- a/compiler-lib/src/backend.rs
+++ b/compiler-lib/src/backend.rs
@@ -1,0 +1,15 @@
+pub trait AsmOut: std::io::Write + std::os::unix::io::AsRawFd {}
+
+impl AsmOut for std::fs::File {}
+
+pub trait AsmBackend {
+    fn emit_asm(&mut self, out: &mut dyn AsmOut) -> std::io::Result<()>;
+}
+
+pub mod amd64 {
+    // TODO: AMD64 backend
+}
+
+pub mod molki {
+    // TODO: MolkiBackend
+}

--- a/compiler-lib/src/firm/method_body_generator.rs
+++ b/compiler-lib/src/firm/method_body_generator.rs
@@ -28,7 +28,7 @@ pub struct MethodBodyGenerator<'ir, 'src, 'ast> {
     runtime: &'ir Runtime,
     type_system: &'ir TypeSystem<'src, 'ast>,
     type_analysis: &'ir TypeAnalysis<'src, 'ast>,
-    strtab: &'ir mut StringTable<'src>,
+    strtab: &'ir StringTable<'src>,
 }
 
 enum ActiveBlock {
@@ -44,7 +44,7 @@ impl<'a, 'ir, 'src, 'ast> MethodBodyGenerator<'ir, 'src, 'ast> {
         type_system: &'ir TypeSystem<'src, 'ast>,
         type_analysis: &'ir TypeAnalysis<'src, 'ast>,
         runtime: &'ir Runtime,
-        strtab: &'ir mut StringTable<'src>,
+        strtab: &'ir StringTable<'src>,
     ) -> Self {
         Self {
             graph,
@@ -82,7 +82,7 @@ impl<'a, 'ir, 'src, 'ast> MethodBodyGenerator<'ir, 'src, 'ast> {
         let args = self.graph.args();
 
         if !self.method_def.is_static {
-            let this_symbol = self.strtab.intern("this");
+            let this_symbol = self.strtab.this_symbol();
             let this_var = self.new_local_var(this_symbol, Mode::P());
             block.set_value(this_var, args.new_proj(0, Mode::P()));
         }

--- a/compiler-lib/src/firm/mod.rs
+++ b/compiler-lib/src/firm/mod.rs
@@ -26,30 +26,27 @@ pub use self::{
     firm_program::*, method_body_generator::MethodBodyGenerator,
     program_generator::ProgramGenerator, runtime::Runtime,
 };
+use lazy_static::lazy_static;
 
-use failure::{Error, Fail};
+use failure::Fail;
 
 use crate::{
     optimization,
     strtab::StringTable,
     type_checking::{type_analysis::TypeAnalysis, type_system::TypeSystem},
-    OutputSpecification,
 };
 use libfirm_rs::{bindings, types::TyTrait};
 use std::{
     ffi::{CStr, CString},
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 /// Enable or disable behaviour during the lowering phase
 #[derive(Debug, Clone, Default)]
 pub struct Options {
-    pub dump_folder: PathBuf,
     pub dump_firm_graph: bool,
     pub dump_class_layouts: bool,
-    pub dump_assembler: Option<OutputSpecification>,
-    pub optimizations: optimization::Level,
 }
 
 #[derive(Debug, Fail)]
@@ -58,108 +55,192 @@ pub enum FirmError {
     EmitAsmFailure { path: PathBuf },
 }
 
-unsafe fn setup() {
-    libfirm_rs::init();
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum FirmContextState {
+    // Each of the following 3 can leapfrog, but not jump back
+    Built,
+    Dumped,
+    Optimized,
 
-    // this call panics on error
-    let triple = bindings::ir_get_host_machine_triple();
-    bindings::ir_target_set_triple(triple);
-
-    // pic=1 means 'generate position independent code'
-    bindings::ir_target_option(CString::new("pic=1").expect("CString::new failed").as_ptr());
-
-    bindings::ir_target_init();
-
-    bindings::set_optimize(0);
+    // Terminal 1
+    AsmEmitted,
+    // Terminal 2
+    ExternalBackend,
 }
 
-pub unsafe fn build<'src, 'ast>(
-    opts: &Options,
-    type_system: &'src TypeSystem<'src, 'ast>,
-    type_analysis: &'src TypeAnalysis<'src, 'ast>,
-    strtab: &'src mut StringTable<'src>,
-) -> Result<(), Error> {
-    setup();
+/// FirmContext is a singleton that represents the global state of libFIRM
+/// library configuration and FIRM-graph construction.
+pub struct FirmContext<'src, 'ast> {
+    state: FirmContextState,
 
-    let rt = std::rc::Rc::new(Runtime::new(box runtime::Mjrt)); // FIXME constant
-    let generator = ProgramGenerator::new(rt, type_system, type_analysis, strtab);
-    let program = generator.generate();
-    if !opts.dump_folder.exists() {
-        fs::create_dir_all(&opts.dump_folder).expect("Failed to create output directory");
-    }
+    dump_dir: PathBuf,
 
-    let dump_folder_cstr = CString::new(opts.dump_folder.to_string_lossy().as_bytes()).unwrap();
-    bindings::ir_set_dump_path(dump_folder_cstr.as_ptr());
+    // outputs
+    program: FirmProgram<'src, 'ast>,
+}
 
-    if opts.dump_firm_graph {
-        let suffix = CString::new("high-level").unwrap();
-        bindings::dump_all_ir_graphs(suffix.as_ptr());
-    }
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 
-    if opts.dump_class_layouts {
-        for class in program.classes.values() {
-            #[allow(clippy::cast_ptr_alignment)]
-            bindings::dump_type_to_file(
-                libc::fopen(
-                    opts.dump_folder
-                        .join(class.borrow().def.name.as_str())
-                        .with_extension("layout")
-                        .to_str()
-                        .and_then(|s| CString::new(s).ok())
-                        .unwrap()
-                        .as_ptr() as *mut i8,
-                    CStr::from_bytes_with_nul(b"w\0").unwrap().as_ptr() as *mut i8,
-                ) as *mut libfirm_rs::bindings::_IO_FILE,
-                class.borrow().entity.ty().ir_type(),
+lazy_static! {
+    static ref FIRM_CONTEXT_INITIALIZED: AtomicBool = AtomicBool::new(false);
+}
+
+impl<'src, 'ast> FirmContext<'src, 'ast> {
+    ///
+    /// * Initialize libFIRM
+    /// * Setup libFIRM target options in case libFirm is used for lowering
+    ///   (TODO can we move this
+    /// to a libFIRM backend?)
+    /// * Build a FIRM graph from the AST stored in `type_system`.
+    ///
+    /// The lowering / target configuration of libFIRM is stored in global
+    /// storage. Hence, this function must be **called at most once**, and
+    /// it will panic otherwise.
+    pub fn build(
+        dump_dir: &Path,
+        type_system: &'src TypeSystem<'src, 'ast>,
+        type_analysis: &'src TypeAnalysis<'src, 'ast>,
+        strtab: &'src StringTable<'src>,
+        rtlib: Box<dyn runtime::RTLib>,
+    ) -> FirmContext<'src, 'ast> {
+        let dump_dir = dump_dir.to_owned();
+        if !dump_dir.exists() {
+            fs::create_dir_all(&dump_dir).expect("Failed to create output directory");
+        }
+
+        // This block protects against concurrent use of libFIRM, which is necessary
+        // because the backend-configuration is stored in globals inside libFIRM.
+        let prev = FIRM_CONTEXT_INITIALIZED.compare_and_swap(false, true, SeqCst);
+        if prev {
+            panic!(
+                "libFIRM lowering context initialized, concurrent or \
+                 repeated use not supported due to library-internal state"
             );
+        } else {
+            unsafe {
+                libfirm_rs::init();
+
+                // this call panics on error
+                let triple = bindings::ir_get_host_machine_triple();
+                bindings::ir_target_set_triple(triple);
+
+                // pic=1 means 'generate position independent code'
+                bindings::ir_target_option(
+                    CString::new("pic=1").expect("CString::new failed").as_ptr(),
+                );
+                bindings::ir_target_init();
+                bindings::set_optimize(0);
+
+                // manually verified that the char* is copied internally,
+                // thus it's ok to drop CString right away
+                let dump_dir_cstr = CString::new(dump_dir.to_str().unwrap().as_bytes()).unwrap();
+                bindings::ir_set_dump_path(dump_dir_cstr.as_ptr());
+            }
+        }
+
+        let runtime = std::rc::Rc::new(Runtime::new(rtlib));
+        let generator = ProgramGenerator::new(runtime, type_system, type_analysis, strtab);
+        let program = generator.generate();
+
+        FirmContext {
+            state: FirmContextState::Built,
+            dump_dir,
+            program,
         }
     }
 
-    opts.optimizations.run_all(&program);
+    /// May panic or fail silently if dumping fails.
+    /// Must only be called once.
+    pub fn high_level_dump(&mut self, opts: &Options) {
+        use self::FirmContextState::*;
+        match self.state {
+            Built => self.state = Dumped,
+            Dumped | Optimized | AsmEmitted | ExternalBackend => {
+                panic!("invalid state {:?}", self.state)
+            }
+        }
 
-    bindings::lower_highlevel();
-    bindings::be_lower_for_target();
+        if opts.dump_firm_graph {
+            let suffix = CString::new("high-level").unwrap();
+            unsafe { bindings::dump_all_ir_graphs(suffix.as_ptr()) };
+        }
 
-    if let Some(ref output_spec) = opts.dump_assembler {
-        // TODO: real label
-        let label = CStr::from_bytes_with_nul(b"<stdin>\0").unwrap().as_ptr();
-
-        match output_spec {
-            OutputSpecification::Stdout => bindings::be_main(bindings::stdout, label),
-            OutputSpecification::File(path) => {
-                // NOTE: we could also do:
-                // - open file with rust API
-                // - get a file pointer using as_raw_fd()
-                // - use libc::fdopen() to convert the file pointer to a FILE struct
-                let mut cpath = path.to_string_lossy().to_string();
-                cpath.push('\0');
-
-                let path_cstr = CStr::from_bytes_with_nul(cpath.as_bytes())
-                    .unwrap()
-                    .as_ptr();
-
-                let assembly_file = libc::fopen(
-                    path_cstr,
-                    CStr::from_bytes_with_nul(b"w\0").unwrap().as_ptr(),
-                );
-
-                if assembly_file.is_null() {
-                    return Err(FirmError::EmitAsmFailure { path: path.clone() }.into());
+        if opts.dump_class_layouts {
+            for class in self.program.classes.values() {
+                let outpath = self
+                    .dump_dir
+                    .join(class.borrow().def.name.as_str())
+                    .with_extension("layout")
+                    .to_str()
+                    .and_then(|s| CString::new(s).ok())
+                    .unwrap();
+                let mode = CStr::from_bytes_with_nul(b"w\0").unwrap().as_ptr() as *mut i8;
+                unsafe {
+                    let file = libc::fopen(outpath.as_ptr() as *mut i8, mode);
+                    #[allow(clippy::cast_ptr_alignment)]
+                    bindings::dump_type_to_file(
+                        file as *mut libfirm_rs::bindings::_IO_FILE,
+                        class.borrow().entity.ty().ir_type(),
+                    );
+                    libc::fclose(file);
                 }
-
-                #[allow(clippy::cast_ptr_alignment)]
-                bindings::be_main(assembly_file as *mut bindings::_IO_FILE, label);
-
-                libc::fclose(assembly_file);
             }
         }
     }
 
-    // This is necessary to extend the lifetime of program
-    // data beyond their usage within libfirm. See comments
-    // in the head of this file.
-    drop(program);
+    /// Must only be called once.
+    pub fn run_optimizations(&mut self, optimizations: optimization::Level) {
+        use self::FirmContextState::*;
+        match self.state {
+            Built | Dumped => self.state = Optimized,
+            Optimized | AsmEmitted | ExternalBackend => panic!("invalid state {:?}", self.state),
+        }
 
-    bindings::ir_finish();
-    Ok(())
+        // Placebo const ref here, in fact, optimizations will change the program.
+        optimizations.run_all(&self.program);
+    }
+
+    /// Must only be called once.
+    pub fn use_external_backend(&mut self) -> &FirmProgram<'src, 'ast> {
+        use self::FirmContextState::*;
+        match self.state {
+            Built | Dumped | Optimized => self.state = ExternalBackend,
+            ExternalBackend | AsmEmitted => panic!("invalid state {:?}", self.state),
+        }
+        &self.program
+    }
+}
+
+use crate::backend;
+
+impl backend::AsmBackend for FirmContext<'_, '_> {
+    /// This implementation of `emit_asm` may only be called once and will panic
+    /// on subsequent calls.
+    fn emit_asm(&mut self, out: &mut dyn backend::AsmOut) -> std::io::Result<()> {
+        use self::FirmContextState::*;
+        match self.state {
+            Built | Dumped | Optimized => self.state = AsmEmitted,
+            AsmEmitted | ExternalBackend => panic!("invalid state {:?}", self.state),
+        }
+
+        // this can only happen once, and is protected by the state guard above
+        unsafe {
+            bindings::lower_highlevel();
+            bindings::be_lower_for_target();
+
+            // TODO: real label
+            let label = CStr::from_bytes_with_nul(b"<unknown>\0").unwrap().as_ptr();
+
+            // TODO libc and libFIRM error checks
+            let fd = out.as_raw_fd();
+            let mode = CStr::from_bytes_with_nul(b"w\0").unwrap().as_ptr();
+            let assembly_file = libc::fdopen(fd, mode);
+            #[allow(clippy::cast_ptr_alignment)]
+            bindings::be_main(assembly_file as *mut bindings::_IO_FILE, label);
+            // not close, since we used fdopen (will be closed by creator of `out`)
+            libc::fflush(assembly_file);
+        }
+
+        Ok(())
+    }
 }

--- a/compiler-lib/src/firm/program_generator.rs
+++ b/compiler-lib/src/firm/program_generator.rs
@@ -16,7 +16,7 @@ pub struct ProgramGenerator<'src, 'ast> {
     runtime: Rc<Runtime>,
     type_system: &'src TypeSystem<'src, 'ast>,
     type_analysis: &'src TypeAnalysis<'src, 'ast>,
-    strtab: &'src mut StringTable<'src>,
+    strtab: &'src StringTable<'src>,
 }
 
 impl<'src, 'ast> ProgramGenerator<'src, 'ast> {
@@ -24,7 +24,7 @@ impl<'src, 'ast> ProgramGenerator<'src, 'ast> {
         runtime: Rc<Runtime>,
         type_system: &'src TypeSystem<'src, 'ast>,
         type_analysis: &'src TypeAnalysis<'src, 'ast>,
-        strtab: &'src mut StringTable<'src>,
+        strtab: &'src StringTable<'src>,
     ) -> Self {
         Self {
             runtime,
@@ -70,7 +70,7 @@ impl<'src, 'ast> ProgramGenerator<'src, 'ast> {
             &self.type_system,
             &self.type_analysis,
             &self.runtime,
-            &mut self.strtab,
+            &self.strtab,
         );
         method_body_gen.gen_method(body);
         graph.finalize_construction();

--- a/compiler-lib/src/lib.rs
+++ b/compiler-lib/src/lib.rs
@@ -20,6 +20,7 @@ extern crate derive_more;
 
 mod analysis;
 pub mod asciifile;
+pub mod backend;
 #[macro_use]
 mod utils;
 pub mod ast;


### PR DESCRIPTION
FIRM: mod.rs refactoring:

- Goal: split firm::build up into steps such that we can have
  another backend than libFIRM that consumes the FirmProgram
- `firm::build` => `FirmContext::build`
- FirmContext is a singleton, which is the best we can do
  given libFIRM's internal global state (target config)
- FirmContext now only abstracts away the things we do on the FIRM
  graph, in the following order:

  - construction from AST
  - pre-optimization ("high-level") dumping
  - running optimizations on the graph
  - EITHER: use libFIRM as backend
      - we implement AsmBackend for that
  - OR: return FirmProgram, which can be used by an external backend
      - the lowering WIP branch will provide an AsmBackend as well

- Above order is enforced by a state machine (FirmContextState)
  using exhaustive matching at the beginning of each public function
  of FirmContext

CLI restructuring:

- Prepare `--compile` subcommand, and prepare it to support both
  an AMD64 backend and a Molki backend.

Reusable Binary Generation from Assembly:

- binary-production logic was extracted to BinaryGenerator
- A BinaryGenerator uses an AsmBackend to produce a binary
- An AsmBackend can emit assembly that is understood by `cc`