### PR TITLE
Next iteration of load store optimization

### DIFF
--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -460,7 +460,6 @@ impl BinaryGenerator {
             .write(true)
             .truncate(true)
             .read(true) // for dump_asm
-            .truncate(true)
             .create(true)
             .open(&asm_out)?;
         Ok(BinaryGenerator {

--- a/compiler-cli/src/main.rs
+++ b/compiler-cli/src/main.rs
@@ -459,6 +459,7 @@ impl BinaryGenerator {
         let asm_out_file = std::fs::OpenOptions::new()
             .write(true)
             .read(true) // for dump_asm
+            .truncate(true)
             .create(true)
             .open(&asm_out)?;
         Ok(BinaryGenerator {
@@ -500,6 +501,7 @@ impl BinaryGenerator {
             Some(OutputSpecification::File(path)) => Some(
                 box std::fs::OpenOptions::new()
                     .write(true)
+                    .truncate(true)
                     .create(true)
                     .open(path)?,
             ),

--- a/compiler-lib/src/firm_context.rs
+++ b/compiler-lib/src/firm_context.rs
@@ -156,8 +156,7 @@ impl<'src, 'ast> FirmContext<'src, 'ast> {
             Optimized | AsmEmitted | ExternalBackend => panic!("invalid state {:?}", self.state),
         }
 
-        // Placebo const ref here, in fact, optimizations will change the program.
-        optimizations.run_all(&self.program);
+        optimizations.run_all(&mut self.program);
     }
 
     /// Must only be called once.

--- a/compiler-lib/src/optimization/constant_folding.rs
+++ b/compiler-lib/src/optimization/constant_folding.rs
@@ -49,7 +49,7 @@ impl optimization::Local for ConstantFolding {
     fn optimize_function(graph: Graph) -> Outcome {
         // Uncomment this code for debugging and prefix the method to debug with "cur_".
 
-        /*if !graph.entity().name_string().contains("main") {
+        /*if !graph.entity().name_string().contains("cur") {
             return Outcome::Unchanged;
         }*/
 

--- a/compiler-lib/src/optimization/lattices/heap.rs
+++ b/compiler-lib/src/optimization/lattices/heap.rs
@@ -289,14 +289,24 @@ impl Heap {
                 return self.non_const_val(field.ty());
             }
 
-            let mut val = Val::NoInfoYet;
+            let mut val: Option<Val> = None;
             for (_node, intersect_obj) in self.object_infos.iter_mut() {
                 if intersect_obj.ty == class_ty && intersect_obj.mem.intersects(&ptr.target) {
-                    val = val.join(intersect_obj.lookup_field(field));
+                    val = match val {
+                        Some(val) => Some(val.join(&intersect_obj.lookup_field(field))),
+                        None => Some(intersect_obj.lookup_field(field).clone()),
+                    };
                 }
             }
-            assert_ne!(val, Val::NoInfoYet);
-            val
+
+            match val {
+                Some(val) => val,
+                None => {
+                    // maybe implement later when we don't delete objects:
+                    // assert_ne!(val, Val::NoInfoYet);
+                    self.non_const_val(field.ty())
+                }
+            }
         }
     }
 

--- a/compiler-lib/src/optimization/lattices/heap.rs
+++ b/compiler-lib/src/optimization/lattices/heap.rs
@@ -272,6 +272,10 @@ impl Heap {
     }
 
     pub fn lookup_field(&mut self, ptr_node: Node, ptr: &Pointer, field: Entity) -> Val {
+        if ptr.is_null() {
+            return Val::Tarval(Tarval::zero(field.ty().mode()));
+        }
+
         let class_ty = ClassTy::from(field.owner()).unwrap();
 
         if let Some(obj_info) = self.object_infos.get(&ptr_node) {
@@ -324,7 +328,7 @@ impl Heap {
             arr_info.lookup_cell(idx).clone()
         } else {
             if ptr.target.unrestricted {
-                return self.non_const_val(item_ty.array().pointer().into());
+                return self.non_const_val(item_ty);
             }
 
             let mut val = Val::NoInfoYet;

--- a/compiler-lib/src/optimization/lattices/mod.rs
+++ b/compiler-lib/src/optimization/lattices/mod.rs
@@ -96,6 +96,14 @@ impl Val {
         Val::NoInfoYet
     }
 
+    pub fn zero(mode: Mode) -> Val {
+        if mode.is_pointer() {
+            Val::Pointer(Pointer::null())
+        } else {
+            Val::Tarval(Tarval::zero(mode))
+        }
+    }
+
     pub fn from_tarval_initially(val: Tarval, mode: Mode) -> Val {
         match val.kind() {
             TarvalKind::Bad if mode.is_pointer() => {

--- a/compiler-lib/src/optimization/lattices/mod.rs
+++ b/compiler-lib/src/optimization/lattices/mod.rs
@@ -1,7 +1,7 @@
 mod heap;
 pub use self::heap::*;
 
-use libfirm_rs::{Tarval, TarvalKind};
+use libfirm_rs::{Mode, Tarval, TarvalKind};
 use std::{fmt, rc::Rc};
 
 pub trait Lattice: Eq + Clone {
@@ -85,11 +85,10 @@ impl fmt::Debug for ConstantFoldingLattice {
 pub enum Val {
     NoInfoYet,
     Tarval(Tarval),
-    ObjPointers(PointerSet),
-    ArrPointers(PointerSet),
+    Pointer(Pointer),
     Heap(Rc<Heap>),
     Tuple(Box<Val>, Box<Val>),
-    NonConstant,
+    Invalid,
 }
 
 impl Val {
@@ -97,9 +96,19 @@ impl Val {
         Val::NoInfoYet
     }
 
-    pub fn from_tarval(val: Tarval) -> Val {
+    pub fn from_tarval_initially(val: Tarval, mode: Mode) -> Val {
         match val.kind() {
-            TarvalKind::Bad => Val::NonConstant,
+            TarvalKind::Bad if mode.is_pointer() => {
+                Val::Pointer(Pointer::to(MemoryArea::unrestricted()))
+            }
+            TarvalKind::Unknown => Val::NoInfoYet,
+            _ if mode.is_pointer() && val.is_zero() => Val::Pointer(Pointer::null()),
+            _ => Val::Tarval(val),
+        }
+    }
+
+    pub fn from_tarval_internal(val: Tarval) -> Val {
+        match val.kind() {
             TarvalKind::Unknown => Val::NoInfoYet,
             _ => Val::Tarval(val),
         }
@@ -111,7 +120,6 @@ impl Val {
 
     pub fn tuple_1(&self) -> &Val {
         match self {
-            Val::NonConstant => &Val::NonConstant,
             Val::Tuple(t1, _t2) => &t1,
             Val::NoInfoYet => &Val::NoInfoYet,
             val => panic!("Invalid data type {:?}", val),
@@ -120,24 +128,40 @@ impl Val {
 
     pub fn tuple_2(&self) -> &Val {
         match self {
-            Val::NonConstant => &Val::NonConstant,
             Val::Tuple(_t1, t2) => &t2,
             Val::NoInfoYet => &Val::NoInfoYet,
             val => panic!("Invalid data type {:?}", val),
         }
     }
+
+    /*pub fn update_dom_depth(self, dom_depth: usize) -> Self {
+        match self {
+            //Val::Heap(heap) => heap.update_dom_depth
+            Val::NoInfoYet | Val::Tarval(_) => self,
+            Val::Heap(heap) => {
+                let mut heap = (&*heap).clone();
+                heap.update_dom_depth(dom_depth);
+                Val::Heap(Rc::new(heap))
+            }
+            Val::Pointer(ptrs) => {
+                let mut ptrs = ptrs.clone();
+                ptrs.update_dom_depth(dom_depth);
+                Val::Pointer(ptrs)
+            }
+            val => panic!("{:?} is not supported.", val),
+        }
+    }*/
 }
 
 impl Lattice for Val {
     fn is_progression_of(&self, other: &Self) -> bool {
         use self::Val::*;
         match (self, other) {
-            (NonConstant, _) | (_, NoInfoYet) => true,
+            // todo
+            //(NonConst(_), _) => true,
+            (_, NoInfoYet) => true,
             (Tarval(val1), Tarval(val2)) => val1.lattice_eq(*val2),
-            (ObjPointers(ps), Tarval(val)) => ps.can_be_null() && val.is_zero(),
-            (ArrPointers(ps), Tarval(val)) => ps.can_be_null() && val.is_zero(),
-            (ObjPointers(ps1), ObjPointers(ps2)) => ps1.is_progression_of(ps2),
-            (ArrPointers(ps1), ArrPointers(ps2)) => ps1.is_progression_of(ps2),
+            (Pointer(ps1), Pointer(ps2)) => ps1.is_progression_of(ps2),
             (Heap(heap1), Heap(heap2)) => heap1.is_progression_of(heap2),
             (Tuple(a1, a2), Tuple(b1, b2)) => a1.is_progression_of(b1) && a2.is_progression_of(b2),
             _ => false,
@@ -147,27 +171,33 @@ impl Lattice for Val {
     fn join(&self, other: &Self) -> Self {
         use self::Val::*;
         match (self, other) {
-            (NonConstant, _) | (_, NonConstant) => NonConstant,
+            //(NonConst(ptrs1), NonConst(ptrs2)) => NonConst(ptrs1.join(ptrs2)),
+            //| NonConstant) => NonConstant,
             (NoInfoYet, arg2) => arg2.clone(),
             (arg1, NoInfoYet) => arg1.clone(),
             (Tarval(val1), Tarval(val2)) => {
-                if val1.lattice_eq(*val2) {
+                Val::from_tarval_internal(val1.join(*val2))
+                /*if val1.lattice_eq(*val2) {
                     Tarval(*val1)
                 } else {
-                    NonConstant
-                }
+                    NonConstant(Pointer::new_empty())
+                }*/
             }
-            (Tarval(val), ObjPointers(ps)) | (ObjPointers(ps), Tarval(val)) if val.is_zero() => {
-                ObjPointers(ps.with_null())
-            }
-            (Tarval(val), ArrPointers(ps)) | (ArrPointers(ps), Tarval(val)) if val.is_zero() => {
-                ArrPointers(ps.with_null())
-            }
-            (ObjPointers(ps1), ObjPointers(ps2)) => ObjPointers(ps1.join(ps2)),
-            (ArrPointers(ps1), ArrPointers(ps2)) => ArrPointers(ps1.join(ps2)),
+            (Pointer(ps1), Pointer(ps2)) => Pointer(ps1.join(ps2)),
             (Heap(heap1), Heap(heap2)) => Heap(Rc::new(heap1.join(heap2))),
             (Tuple(a1, a2), Tuple(b1, b2)) => Val::tuple(a1.join(b1), a2.join(b2)),
-            _ => panic!("Cannot join values of different types."),
+            (Pointer(ps), Tarval(tval)) | (Tarval(tval), Pointer(ps)) if ps.is_null() => {
+                log::debug!(
+                    "Join {:?} with {:?} that should happen only when load store is disabled",
+                    ps,
+                    tval
+                );
+                Tarval(*tval)
+            }
+            (val1, val2) => panic!(
+                "Cannot join value {:?} with {:?} - they have different types.",
+                val1, val2
+            ),
         }
     }
 }
@@ -175,12 +205,13 @@ impl Lattice for Val {
 impl fmt::Debug for Val {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Val::ObjPointers(ptrs) | Val::ArrPointers(ptrs) => write!(f, "{:?}", ptrs),
+            Val::Pointer(ptrs) => write!(f, "{:?}", ptrs),
             Val::Tarval(val) => write!(f, "{:?}", val),
-            Val::NonConstant => write!(f, "Not Const"),
+            //Val::NonConstant => write!(f, "Not Const"),
             Val::NoInfoYet => write!(f, "No info"),
             Val::Heap(heap) => write!(f, "{:?}", heap),
             Val::Tuple(..) => write!(f, "Tuple"),
+            Val::Invalid => write!(f, "Invalid"),
         }
     }
 }

--- a/compiler-lib/src/optimization/mod.rs
+++ b/compiler-lib/src/optimization/mod.rs
@@ -15,7 +15,7 @@ mod lattices;
 /// An optimization that optimizes the whole program by examining all function
 /// graphs at once.
 pub trait Interprocedural {
-    fn optimize(program: &FirmProgram<'_, '_>) -> Outcome;
+    fn optimize(program: &mut FirmProgram<'_, '_>) -> Outcome;
 }
 
 /// An optimization that only works on a single graph and therefore does not
@@ -28,7 +28,7 @@ impl<T> Interprocedural for T
 where
     T: Local,
 {
-    fn optimize(program: &FirmProgram<'_, '_>) -> Outcome {
+    fn optimize(program: &mut FirmProgram<'_, '_>) -> Outcome {
         let mut collector = OutcomeCollector::new();
         for method in program.methods.values() {
             if let Some(graph) = method.borrow().graph {
@@ -57,7 +57,7 @@ pub enum Kind {
 }
 
 impl Kind {
-    fn run(self, program: &FirmProgram<'_, '_>) -> Outcome {
+    fn run(self, program: &mut FirmProgram<'_, '_>) -> Outcome {
         match self {
             Kind::ConstantFolding => ConstantFolding::optimize(program),
             Kind::Inline => Inlining::optimize(program),
@@ -135,7 +135,7 @@ impl Optimization {
         self.flags.iter().any(|f| *f == flag)
     }
 
-    fn run(&self, program: &FirmProgram<'_, '_>) -> Outcome {
+    fn run(&self, program: &mut FirmProgram<'_, '_>) -> Outcome {
         let outcome = self.kind.run(program);
         self.apply_flags(program);
         outcome
@@ -188,7 +188,7 @@ impl OutcomeCollector {
 impl Level {
     /// run the list of optimizations defined by the optimization level
     /// on the given program
-    pub fn run_all(&self, program: &FirmProgram<'_, '_>) {
+    pub fn run_all(&self, program: &mut FirmProgram<'_, '_>) {
         breakpoint!("before optimization sequence".to_string(), program);
         let measurement_all = Measurement::start("optimization phase");
 

--- a/firm-construction/src/method_body_generator.rs
+++ b/firm-construction/src/method_body_generator.rs
@@ -454,7 +454,8 @@ impl<'a, 'ir, 'src, 'ast> MethodBodyGenerator<'ir, 'src, 'ast> {
             }
             ArrayAccess(target, idx_expr) => {
                 let item_ty = &self.type_analysis.expr_info(expr).ty;
-                let item_ty = ty_from_checked_type(item_ty).expect("not void");
+                let item_ty = ty_from_checked_type(item_ty, self.type_system, self.program)
+                    .expect("not void");
                 let arr_ty = item_ty.array().into();
                 let (act_block, target) = self.gen_value(act_block, target);
                 let (act_block, idx_node) = self.gen_value(act_block, idx_expr);

--- a/firm-construction/src/program_generator.rs
+++ b/firm-construction/src/program_generator.rs
@@ -30,17 +30,25 @@ impl Spans {
     pub fn new() -> Spans {
         Spans::default()
     }
-    pub fn lookup_span(node: impl NodeTrait + Into<Node>) -> Option<Span<'static>> {
+    pub fn lookup_span(node: impl NodeTrait) -> Option<Span<'static>> {
         SPANS.lock().unwrap().lookup_span_(node)
+    }
+
+    pub fn span_str(node: impl NodeTrait) -> String {
+        if let Some(span) = Self::lookup_span(node) {
+            format!(" [src:{}]", span)
+        } else {
+            "".to_string()
+        }
     }
 
     pub fn add_spans(spans: &HashMap<Node, Span<'_>>) {
         SPANS.lock().unwrap().add_spans_(spans);
     }
 
-    fn lookup_span_(&self, node: impl NodeTrait + Into<Node>) -> Option<Span<'static>> {
+    fn lookup_span_(&self, node: impl NodeTrait) -> Option<Span<'static>> {
         let map = self.spans.borrow();
-        map.get(&node.into()).cloned()
+        map.get(&node.as_node()).cloned()
     }
 
     fn add_spans_(&self, spans: &HashMap<Node, Span<'_>>) {

--- a/firm-construction/src/type_translation.rs
+++ b/firm-construction/src/type_translation.rs
@@ -1,4 +1,5 @@
-use crate::type_checking::type_system::CheckedType;
+use super::FirmProgram;
+use crate::type_checking::type_system::{CheckedType, TypeSystem};
 use libfirm_rs::{
     types::{PrimitiveTy, Ty, TyTrait},
     Mode,
@@ -6,16 +7,31 @@ use libfirm_rs::{
 
 /// `None` indicates that the given type is not convertible, which
 /// is not necessarily an error (e.g. `void`)
-pub fn ty_from_checked_type(ct: &CheckedType<'_>) -> Option<Ty> {
+pub fn ty_from_checked_type<'src, 'ast>(
+    ct: &CheckedType<'src>,
+    type_system: &'_ TypeSystem<'src, 'ast>,
+    program: &'_ FirmProgram<'src, 'ast>,
+) -> Option<Ty> {
     let ty = match ct {
         CheckedType::Int => PrimitiveTy::i32().into(),
         CheckedType::Void => return None,
-        CheckedType::TypeRef(_) => PrimitiveTy::ptr().into(),
-        CheckedType::Array(checked_type) => ty_from_checked_type(checked_type)
-            .expect("Arrays are never of type `void`")
-            .array()
-            .pointer()
-            .into(),
+        CheckedType::TypeRef(class_def_id) => {
+            let def = type_system.class(*class_def_id);
+            let class = program.class(def).unwrap();
+            let ty = class.borrow().entity.ty();
+            ty.pointer().into()
+            // If, for some unforeseen reason, the line above does not work,
+            // return this instead: `PrimitiveTy::ptr().into()`.
+            // However, this looses the class type we are pointing at.
+            // We need this information in optimizations.
+        }
+        CheckedType::Array(checked_type) => {
+            ty_from_checked_type(checked_type, type_system, program)
+                .expect("Arrays are never of type `void`")
+                .array()
+                .pointer()
+                .into()
+        }
         CheckedType::Boolean => PrimitiveTy::bool().into(),
         CheckedType::Null => unreachable!(),
         CheckedType::UnknownType(_) => unreachable!(),

--- a/firm-construction/src/type_translation.rs
+++ b/firm-construction/src/type_translation.rs
@@ -47,7 +47,3 @@ pub fn get_firm_mode(ty: &CheckedType<'_>) -> Option<Mode> {
         CheckedType::Void | CheckedType::UnknownType(_) => None,
     }
 }
-
-pub fn size_of(ty: &CheckedType<'_>) -> Option<u32> {
-    get_firm_mode(ty).map(|mode| mode.size_bytes())
-}

--- a/integration-tests/optimization/load-store-op.mj
+++ b/integration-tests/optimization/load-store-op.mj
@@ -2,7 +2,7 @@
 optimizations: [ConstantFolding]
 expect: change
 stdout:
-    is: "1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n"
+    is: "1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n"
 
 ---
 class Obj {
@@ -28,7 +28,6 @@ class Main {
         System.out.println(d);
     }
 
-
     public void test() {
         testDirectWrite();
         testRefWriteClear();
@@ -37,6 +36,15 @@ class Main {
         testMethodCall();
         testArrayDirectWrite();
         testArrayIndirectWrite();
+        testPhi();
+    }
+
+    public int y;
+    public int x;
+    public void testPhi() {
+        if (y == 2) x = 1;
+
+        assertVariable(x + 1, x + 2, x + 3, x + 4);
     }
 
     public void testArrayIndirectWrite() {

--- a/integration-tests/optimization/load-store-op.mj
+++ b/integration-tests/optimization/load-store-op.mj
@@ -1,0 +1,172 @@
+---
+optimizations: [ConstantFolding]
+expect: change
+stdout:
+    is: "1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n1\n2\n3\n4\n"
+
+---
+class Obj {
+    public Obj obj;
+    public int x;
+}
+
+class Main {
+    public static void main(String[] args) {
+        new Main().test();
+    }
+
+    public void assertConstant(int a, int b, int c, int d) {
+        System.out.println(a);
+        System.out.println(b);
+        System.out.println(c);
+        System.out.println(d);
+    }
+    public void assertVariable(int a, int b, int c, int d) {
+        System.out.println(a);
+        System.out.println(b);
+        System.out.println(c);
+        System.out.println(d);
+    }
+
+
+    public void test() {
+        testDirectWrite();
+        testRefWriteClear();
+        testArgAccess1();
+        testArgAccess2();
+        testMethodCall();
+        testArrayDirectWrite();
+        testArrayIndirectWrite();
+    }
+
+    public void testArrayIndirectWrite() {
+        arrayIndirectWrite1(1, 1);
+        arrayIndirectWrite2(1, 1);
+    }
+
+    public void arrayIndirectWrite1(int idx1, int idx2) {
+        int[] arr = new int[4];
+        arr[0] = 1;
+        int vEq1Const = arr[0];
+        arr[idx1] = 2;
+        int vEq2Const = arr[idx1];
+        arr[idx2] = 3;
+
+        assertConstant(vEq1Const, vEq2Const, arr[idx2], 4);
+        assertVariable(arr[0], arr[0] + 1, arr[idx1], arr[3] + 4);
+    }
+
+    public void arrayIndirectWrite2(int idx1, int idx2) {
+        Obj[] arr = new Obj[4];
+        Obj a = new Obj();
+        a.x = 1;
+        Obj b = new Obj();
+        b.x = 2;
+        Obj c = new Obj();
+        c.x = 3;
+
+        arr[0] = a;
+        Obj a1 = arr[0];
+        arr[1] = a1;
+        arr[idx1] = b;
+        arr[2] = c;
+        arr[idx2] = c;
+
+        assertConstant(1, 2, arr[idx2].x, 4);
+        assertVariable(arr[0].x, arr[1].x - 1, arr[2].x, arr[2].x + 1);
+    }
+
+    public void testArrayDirectWrite() {
+        int[] arr = new int[3];
+        arr[0] = 1;
+        arr[1] = 3;
+        arr[1] = 2;
+
+        assertConstant(arr[0], arr[1], arr[2] + 3, 4);
+    }
+
+    public void testMethodCall() {
+        Obj a = new Obj();
+        Obj b = new Obj();
+        b.x = 1;
+        b.obj = new Obj();
+
+        a.obj = a;
+        changeDeep(a); /* a has no reference to b */
+        int axEq3Var = a.x - 1;
+        int bxEq1Const = b.x;
+
+        a.obj = b;
+        changeDeep(a);
+        int bxEq4Var = b.obj.x;
+        a.x = 2;
+
+        /* TODO: assertConstant(bxEq1Const, a.x, 3, 4); */
+        assertVariable(bxEq4Var - 3, bxEq4Var - 2, axEq3Var, bxEq4Var);
+    }
+
+    public void changeDeep(Obj o) {
+        o.obj.obj.x = 4;
+    }
+
+    public void testArgAccess2() {
+        Obj a = new Obj();
+        argAccess2Func(a, a);
+    }
+
+    public void argAccess2Func(Obj a, Obj b) {
+        Obj c = new Obj();
+        a.obj = c;
+
+        c.x = 1;
+        b.obj.x = 2;
+
+        int cxEq2Var = c.x;
+        assertVariable(cxEq2Var - 1, cxEq2Var, cxEq2Var + 1, cxEq2Var + 2);
+    }
+
+    public void testArgAccess1() {
+        Obj a = new Obj();
+        Obj b = new Obj();
+        argAccess1Func(a, b);
+    }
+
+    public void argAccess1Func(Obj a, Obj b) {
+        Obj c = new Obj();
+        a.x = 1;
+        c.x = 3;
+        int axEq1 = a.x;
+        c.x = 4;
+        b.x = 2;
+        assertConstant(axEq1, b.x, 3, c.x);
+        int axEq1Var = a.x;
+        assertVariable(axEq1Var, axEq1Var + 1, axEq1Var + 2, axEq1Var + 3);
+    }
+
+    public void testRefWriteClear() {
+        Obj a = new Obj(); /* 1n -> [1] */
+        Obj b = new Obj(); /* 2n -> [2] */
+        Obj c = new Obj(); /* 3n -> [3] */
+        a.obj = b; /* 1n.obj -> [2] */
+        c.x = 3;
+        a.x = 1;
+        b.x = 5;
+        Obj b2 = a.obj; /* 4n -> [2] */
+        b2.x = 2; /* invalidates [2].x */
+
+        assertConstant(a.x, 2, c.x, 4);
+        int bxEq2Var = b.x;
+        assertVariable(bxEq2Var - 1, bxEq2Var, bxEq2Var + 1, bxEq2Var + 2);
+    }
+
+    public void testDirectWrite() {
+        Obj a = new Obj();
+        Obj b = new Obj();
+        a.x = 3;
+        b.x = 4;
+        a.x = 1;
+        b.x = 2;
+
+        assertConstant(a.x, b.x, 3, 4);
+    }
+}

--- a/libfirm-rs/src/entity.rs
+++ b/libfirm-rs/src/entity.rs
@@ -42,6 +42,10 @@ impl Entity {
         unsafe { Ty::from_ir_type(bindings::get_entity_type(self.0)) }
     }
 
+    pub fn owner(self) -> Ty {
+        unsafe { Ty::from_ir_type(bindings::get_entity_owner(self.0)) }
+    }
+
     pub fn name(self) -> &'static CStr {
         unsafe { CStr::from_ptr(bindings::get_entity_name(self.0)) }
     }

--- a/libfirm-rs/src/graph.rs
+++ b/libfirm-rs/src/graph.rs
@@ -1,9 +1,7 @@
 use super::{
     entity::Entity,
     mode::Mode,
-    nodes::{
-        Block, End, EndKeepAliveIterator, NoMem, Node, NodeTrait, Proj, ProjKind, Start, ValueNode,
-    },
+    nodes::{Block, End, EndKeepAliveIterator, NoMem, Node, NodeTrait, Proj, Start},
 };
 use libfirm_rs_bindings as bindings;
 use std::{
@@ -194,51 +192,6 @@ impl Graph {
     pub fn exchange(prev: impl NodeTrait, new: impl NodeTrait) {
         unsafe {
             bindings::exchange(prev.internal_ir_node(), new.internal_ir_node());
-        }
-    }
-
-    pub fn exchange_value(prev: impl ValueNode + Into<Node>, new: impl ValueNode + Into<Node>) {
-        let prev: Node = prev.into();
-        let new: Node = new.into();
-        use self::Node::*;
-        match prev {
-            /* IMPROVEMENT?
-            This might be more elegant, but does not do the exact same:
-            It fails if there are multiple projects to that pin!
-            Node::Div(div) => {
-                div.out_proj_res().then(|res| Graph::exchange(res, const_node))
-                div.out_proj_m().then(|mem| Graph::exchange(mem, div.mem()))
-            }
-            */
-            Div(node) => {
-                for out_node in node.out_nodes() {
-                    match out_node {
-                        Proj(res_proj, ProjKind::Div_Res(_)) => {
-                            Graph::exchange(res_proj, new);
-                        }
-                        Proj(m_proj, ProjKind::Div_M(_)) => {
-                            Graph::exchange(m_proj, node.mem());
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Mod(node) => {
-                for out_node in node.out_nodes() {
-                    match out_node {
-                        Proj(res_proj, ProjKind::Mod_Res(_)) => {
-                            Graph::exchange(res_proj, new);
-                        }
-                        Proj(m_proj, ProjKind::Mod_M(_)) => {
-                            Graph::exchange(m_proj, node.mem());
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            node => {
-                Graph::exchange(node, new);
-            }
         }
     }
 

--- a/libfirm-rs/src/graph.rs
+++ b/libfirm-rs/src/graph.rs
@@ -103,11 +103,11 @@ impl Graph {
         unsafe { bindings::remove_unreachable_code(self.irg) }
     }
 
-    pub fn compute_dominance_frontiers(self) {
-        unsafe { bindings::ir_compute_dominance_frontiers(self.irg) }
+    pub fn compute_doms(self) {
+        unsafe { bindings::compute_doms(self.irg) }
     }
 
-    pub fn walk_topological2<F>(self, mut walker: F)
+    pub fn walk_blkwise_dom_top_down<F>(self, mut walker: F)
     where
         F: FnMut(&Node),
     {

--- a/libfirm-rs/src/mode.rs
+++ b/libfirm-rs/src/mode.rs
@@ -56,6 +56,10 @@ impl Mode {
     pub fn is_mem(self) -> bool {
         self == Mode::M()
     }
+
+    pub fn is_pointer(self) -> bool {
+        self == Mode::P()
+    }
 }
 
 use std::fmt::{self, Debug, Formatter};

--- a/libfirm-rs/src/nodes/nodes_ext.rs
+++ b/libfirm-rs/src/nodes/nodes_ext.rs
@@ -537,7 +537,7 @@ impl NodeDebug for Call {
                 if opts.new_print_class {
                     format!(" {:?}", class_ty)
                 } else {
-                    format!("")
+                    "".to_string()
                 },
                 self.node_id()
             )

--- a/libfirm-rs/src/nodes/value_nodes.rs
+++ b/libfirm-rs/src/nodes/value_nodes.rs
@@ -135,9 +135,9 @@ macro_rules! empty_value_node_impl {
 
 empty_value_node_impl!(Address);
 empty_value_node_impl!(Alloc);
+empty_value_node_impl!(Free);
 empty_value_node_impl!(Bitcast);
 empty_value_node_impl!(Call);
-empty_value_node_impl!(Free);
 empty_value_node_impl!(Load);
 empty_value_node_impl!(Member);
 empty_value_node_impl!(Mulh);

--- a/libfirm-rs/src/types.rs
+++ b/libfirm-rs/src/types.rs
@@ -287,7 +287,9 @@ impl ClassTy {
     }
 
     pub fn idx_of_field(self, field: Entity) -> usize {
-        unsafe { bindings::get_class_member_index(self.ir_type(), field.ir_entity()) }
+        let idx = unsafe { bindings::get_class_member_index(self.ir_type(), field.ir_entity()) };
+        assert!(idx < self.fields().count());
+        idx
     }
 
     pub fn name(self) -> &'static CStr {
@@ -297,6 +299,12 @@ impl ClassTy {
 
     pub fn name_string(self) -> String {
         self.name().to_string_lossy().into_owned()
+    }
+
+    pub fn remove_member(self, member: Entity) {
+        unsafe {
+            bindings::remove_compound_member(self.ir_type(), member.ir_entity());
+        }
     }
 }
 


### PR DESCRIPTION
This PR reimplements load store optimization.
Has support for arrays and objects.

See `integration-tests/optimization/load-store-op.mj` for a test.
Use `assertConstant` and `assertVariable`  to check whether libfirm nodes are folded to a constant or not.
This of course is a problem if an actual method is called like that - further checks must be implemented for that.
But please merge this PR asap if all tests passes to eliminate future merge conflicts.
This needs some more work anyways. For example, unneccessary loads and stores are not removed yet.