### PR TITLE
only run custom assert logic in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "gcollections 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "intervallum 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libfirm-rs 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/integration-tests/optimization/compile_time_fns_test_same_node.mj
+++ b/integration-tests/optimization/compile_time_fns_test_same_node.mj
@@ -1,0 +1,36 @@
+---
+optimizations: [ConstantFolding]
+expect: unchanged
+        
+stdout:
+    is: "9\n9\n4\n"
+---
+
+class Assert {
+    public void is_const_after(int opt_index, int expr) {}
+    public void is_const_before(int opt_index, int expr) {}
+    public void is_not_const_after(int opt_index, int expr) {}
+    public void is_not_const_before(int opt_index, int expr) {}
+    public void is_same_node_after(int opt_index, int expr, int expr2) {}
+    public void is_same_node_before(int opt_index, int expr, int expr2) {}
+    public void is_different_node_after(int opt_index, int expr, int expr2) {}
+    public void is_different_node_before(int opt_index, int expr, int expr2) {}
+}
+
+class CF_Sub {
+  public static void main(String[] args) {
+    Assert expect = new Assert();
+    int a = 9;
+    int b = a;
+    int c = 4;
+
+    expect.is_same_node_before(0, a, b);
+    expect.is_same_node_after(0, a, b);
+    expect.is_different_node_after(0, a, c);
+    expect.is_different_node_before(0, a, c);
+
+    System.out.println(a);
+    System.out.println(b);
+    System.out.println(c);
+  }
+}

--- a/integration-tests/optimization/compile_time_fns_test_same_node.mj
+++ b/integration-tests/optimization/compile_time_fns_test_same_node.mj
@@ -6,31 +6,36 @@ stdout:
     is: "9\n9\n4\n"
 ---
 
-class Assert {
-    public void is_const_after(int opt_index, int expr) {}
-    public void is_const_before(int opt_index, int expr) {}
-    public void is_not_const_after(int opt_index, int expr) {}
-    public void is_not_const_before(int opt_index, int expr) {}
-    public void is_same_node_after(int opt_index, int expr, int expr2) {}
-    public void is_same_node_before(int opt_index, int expr, int expr2) {}
-    public void is_different_node_after(int opt_index, int expr, int expr2) {}
-    public void is_different_node_before(int opt_index, int expr, int expr2) {}
-    public void is_different_node_3_before(int opt_index, int expr, int expr2, int expr3) {}
+class ConstantFoldingAfter {
+    public void is_const(int expr) {}
+    public void is_not_const(int expr) {}
+    public void is_same_node(int expr, int expr2) {}
+    public void is_different_node(int expr, int expr2) {}
+    public void is_different_node_3(int expr, int expr2, int expr3) {}
+}
+
+class ConstantFoldingBefore {
+    public void is_const(int expr) {}
+    public void is_not_const(int expr) {}
+    public void is_same_node(int expr, int expr2) {}
+    public void is_different_node(int expr, int expr2) {}
+    public void is_different_node_3(int expr, int expr2, int expr3) {}
 }
 
 class CF_Sub {
   public static void main(String[] args) {
-    Assert expect = new Assert();
+    ConstantFoldingAfter expect_after = new ConstantFoldingAfter();
+    ConstantFoldingBefore expect_before = new ConstantFoldingBefore();
     int a = 9;
     int b = a;
     int c = 4;
     int d = 2;
 
-    expect.is_same_node_before(0, a, b);
-    expect.is_same_node_after(0, a, b);
-    expect.is_different_node_after(0, a, c);
-    expect.is_different_node_before(0, a, c);
-    expect.is_different_node_3_before(0, a, c, d);
+    expect_before.is_same_node(a, b);
+    expect_after.is_same_node(a, b);
+    expect_after.is_different_node(a, c);
+    expect_before.is_different_node(a, c);
+    expect_before.is_different_node_3(a, c, d);
 
     System.out.println(a);
     System.out.println(b);

--- a/integration-tests/optimization/compile_time_fns_test_same_node.mj
+++ b/integration-tests/optimization/compile_time_fns_test_same_node.mj
@@ -15,6 +15,7 @@ class Assert {
     public void is_same_node_before(int opt_index, int expr, int expr2) {}
     public void is_different_node_after(int opt_index, int expr, int expr2) {}
     public void is_different_node_before(int opt_index, int expr, int expr2) {}
+    public void is_different_node_3_before(int opt_index, int expr, int expr2, int expr3) {}
 }
 
 class CF_Sub {
@@ -23,11 +24,13 @@ class CF_Sub {
     int a = 9;
     int b = a;
     int c = 4;
+    int d = 2;
 
     expect.is_same_node_before(0, a, b);
     expect.is_same_node_after(0, a, b);
     expect.is_different_node_after(0, a, c);
     expect.is_different_node_before(0, a, c);
+    expect.is_different_node_3_before(0, a, c, d);
 
     System.out.println(a);
     System.out.println(b);

--- a/integration-tests/optimization/example_compile_time_fns.mj
+++ b/integration-tests/optimization/example_compile_time_fns.mj
@@ -5,20 +5,32 @@ expect: change
 stdout:
     is: "9\n"
 ---
-class Assert {
-    public void is_const_after(int opt_index, int expr) {}
-    public void is_const_before(int opt_index, int expr) {}
-    public void is_not_const_after(int opt_index, int expr) {}
-    public void is_not_const_before(int opt_index, int expr) {}
+
+class ConstantFoldingAfter {
+    public void is_const(int expr) {}
+}
+
+class ConstantFoldingBefore {
+    public void is_not_const(int expr) {}
+}
+
+class Opt1After {
+    public void is_const(int expr) {}
+    public void is_not_const(int expr) {}
 }
 
 class CF_Sub {
   public static void main(String[] args) {
-    Assert expect = new Assert();
+    ConstantFoldingAfter expect_after = new ConstantFoldingAfter();
+    ConstantFoldingBefore expect_before = new ConstantFoldingBefore();
+
     int a = 14 - 5;
 
-    expect.is_not_const_before(0, a);
-    expect.is_const_after(0, a);
+    expect_before.is_not_const(a);
+    expect_after.is_const(a);
+    /* should not be evaluated since the class name is a mismatch */
+    (new Opt1After()).is_const(a);
+    (new Opt1After()).is_not_const(a);
 
     System.out.println(a);
   }

--- a/integration-tests/optimization/example_compile_time_fns.mj
+++ b/integration-tests/optimization/example_compile_time_fns.mj
@@ -1,0 +1,25 @@
+---
+optimizations: [ConstantFolding]
+expect: change
+        
+stdout:
+    is: "9\n"
+---
+class Assert {
+    public void is_const_after(int opt_index, int expr) {}
+    public void is_const_before(int opt_index, int expr) {}
+    public void is_not_const_after(int opt_index, int expr) {}
+    public void is_not_const_before(int opt_index, int expr) {}
+}
+
+class CF_Sub {
+  public static void main(String[] args) {
+    Assert expect = new Assert();
+    int a = 14 - 5;
+
+    expect.is_not_const_before(0, a);
+    expect.is_const_after(0, a);
+
+    System.out.println(a);
+  }
+}

--- a/optimization/Cargo.toml
+++ b/optimization/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0"
 
 priority-queue = "0.5.2"
 petgraph = "0.4.13"
+lazy_static = "1.2.0"
 
 [dev-dependencies]
 

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -9,7 +9,7 @@ use libfirm_rs::{
 use std::fmt;
 
 /// Set this environment variable to enable these special functions
-pub const ENV_VAR_NAME: &'static str = "COMPRAKT_COMPILE_TIME_MJ_ASSERTS";
+pub const ENV_VAR_NAME: &str = "COMPRAKT_COMPILE_TIME_MJ_ASSERTS";
 
 lazy_static::lazy_static! {
     static ref ENABLED: bool = std::env::var(ENV_VAR_NAME).is_ok();

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -8,6 +8,9 @@ use libfirm_rs::{
 };
 use std::fmt;
 
+/// Set this environment variable to enable these special functions
+pub const ENV_VAR: &'static str = "COMPRAKT_COMPILE_TIME_MJ_ASSERTS";
+
 #[derive(Default, Clone, Debug)]
 pub struct CompileTimeAssertions {}
 
@@ -53,7 +56,15 @@ impl CompileTimeAssertions {
         Self {}
     }
 
+    fn disabled() -> bool {
+        !std::env::var(ENV_VAR).is_ok()
+    }
+
     pub fn check_program(&self, program: &FirmProgram<'_, '_>, phase: Phase) {
+        if CompileTimeAssertions::disabled() {
+            return;
+        }
+
         log::debug!("checking assertions for phase {:?}", phase);
 
         for method in program.methods.values() {
@@ -66,6 +77,10 @@ impl CompileTimeAssertions {
     // check all assertions, panic if the an assertion is
     // wrong.
     pub fn check_graph(&self, graph: Graph, phase: Phase) {
+        if CompileTimeAssertions::disabled() {
+            return;
+        }
+
         graph.walk(|node| {
             if let Some(call) = Node::as_call(*node) {
                 if let Some(method_name) = call.method_name() {

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -127,7 +127,12 @@ fn assert_const(call: nodes::Call, phase: &Phase) {
             assert!(
                 Node::is_const(node),
                 build_assert_msg(
-                    format!("expected {:?} to be a constant {}", node, phase),
+                    format!(
+                        "expected {:?} ({}) to be a constant {}",
+                        node,
+                        Spans::span_str(node),
+                        phase
+                    ),
                     call
                 )
             );
@@ -141,7 +146,12 @@ fn assert_not_const(call: nodes::Call, phase: &Phase) {
             assert!(
                 !Node::is_const(node),
                 build_assert_msg(
-                    format!("expected {:?} to NOT be a constant {}", node, phase),
+                    format!(
+                        "expected {:?} ({}) to NOT be a constant {}",
+                        node,
+                        Spans::span_str(node),
+                        phase
+                    ),
                     call
                 )
             );

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -1,6 +1,7 @@
 //! Injects the class 'Assert' into the mini java runtime, which
 //! contains functions that are evaluated at compile-time.
 use crate::{firm::FirmProgram, optimization};
+use firm_construction::program_generator::Spans;
 use libfirm_rs::{
     nodes::{self, Node},
     Graph,
@@ -102,7 +103,10 @@ fn assert_const(call: nodes::Call, phase: &Phase) {
     if phase.is_match(&phase_filter) {
         assert!(
             Node::is_const(node),
-            format!("expected {:?} to be a constant {}", node, phase)
+            build_assert_msg(
+                format!("expected {:?} to be a constant {}", node, phase),
+                node
+            )
         );
     }
 }
@@ -120,7 +124,22 @@ fn assert_not_const(call: nodes::Call, phase: &Phase) {
     if phase.is_match(&phase_filter) {
         assert!(
             !Node::is_const(node),
-            format!("expected {:?} to NOT be a constant {}", node, phase)
+            build_assert_msg(
+                format!("expected {:?} to NOT be a constant {}", node, phase),
+                node
+            )
         );
     }
+}
+
+fn build_assert_msg(msg: String, node: Node) -> String {
+    format!(
+        "{}{}",
+        if let Some(pos) = Spans::lookup_span(node) {
+            format!("{}: ", pos)
+        } else {
+            "".to_string()
+        },
+        msg
+    )
 }

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -178,30 +178,31 @@ fn assert_node_equality(call: nodes::Call, phase: &Phase, expect_same: bool) {
             )
         );
 
-        let first = nodes[0];
-        for node in &nodes[1..] {
-            assert!(
-                if expect_same {
-                    first == *node
-                } else {
-                    first != *node
-                },
-                build_assert_msg(
-                    format!(
-                        "expected {:?} ({}) and {:?} ({}) to be the same node {}",
-                        first,
-                        Spans::lookup_span(first)
-                            .map(|span| span.as_str())
-                            .unwrap_or(""),
-                        node,
-                        Spans::lookup_span(*node)
-                            .map(|span| span.as_str())
-                            .unwrap_or(""),
-                        phase
-                    ),
-                    call,
-                )
-            );
+        for (idx, curr_node) in nodes.iter().enumerate() {
+            for other in &nodes[(idx + 1)..] {
+                assert!(
+                    if expect_same {
+                        other == curr_node
+                    } else {
+                        other != curr_node
+                    },
+                    build_assert_msg(
+                        format!(
+                            "expected {:?} ({}) and {:?} ({}) to be the same node {}",
+                            curr_node,
+                            Spans::lookup_span(*curr_node)
+                                .map(|span| span.as_str())
+                                .unwrap_or(""),
+                            other,
+                            Spans::lookup_span(*other)
+                                .map(|span| span.as_str())
+                                .unwrap_or(""),
+                            phase
+                        ),
+                        call,
+                    )
+                );
+            }
         }
     }
 }

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -1,0 +1,126 @@
+//! Injects the class 'Assert' into the mini java runtime, which
+//! contains functions that are evaluated at compile-time.
+use crate::{firm::FirmProgram, optimization};
+use libfirm_rs::{
+    nodes::{self, Node},
+    Graph,
+};
+use std::fmt;
+
+#[derive(Default, Clone, Debug)]
+pub struct CompileTimeAssertions {}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Phase {
+    pub opt_idx: usize,
+    pub opt_kind: optimization::Kind,
+    pub is_already_applied: bool,
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} optimization number {}. {}",
+            if self.is_already_applied {
+                "after"
+            } else {
+                "before"
+            },
+            self.opt_idx + 1,
+            self.opt_kind
+        )
+    }
+}
+
+impl Phase {
+    fn is_match(&self, filter: &str) -> bool {
+        if self.opt_kind.to_string() == filter {
+            return true;
+        }
+
+        if let Ok(num) = filter.parse::<usize>() {
+            return self.opt_idx == num;
+        }
+
+        return false;
+    }
+}
+
+impl CompileTimeAssertions {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn check_program(&self, program: &FirmProgram<'_, '_>, phase: Phase) {
+        log::debug!("checking assertions for phase {:?}", phase);
+
+        for method in program.methods.values() {
+            if let Some(graph) = method.borrow().graph {
+                self.check_graph(graph, phase);
+            }
+        }
+    }
+
+    // check all assertions, panic if the an assertion is
+    // wrong.
+    pub fn check_graph(&self, graph: Graph, phase: Phase) {
+        graph.walk(|node| {
+            if let Some(call) = Node::as_call(*node) {
+                if let Some(method_name) = call.method_name() {
+                    match method_name.as_str() {
+                        "Assert$M$is_const_after" if phase.is_already_applied => {
+                            assert_const(call, &phase)
+                        }
+                        "Assert$M$is_const_before" if !phase.is_already_applied => {
+                            assert_const(call, &phase)
+                        }
+                        "Assert$M$is_not_const_after" if phase.is_already_applied => {
+                            assert_not_const(call, &phase)
+                        }
+                        "Assert$M$is_not_const_before" if !phase.is_already_applied => {
+                            assert_not_const(call, &phase)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn assert_const(call: nodes::Call, phase: &Phase) {
+    let phase_filter_node = call.args().nth(1).unwrap();
+    // TODO: somehow suppport specifying optimizations by name instead of indices
+    let phase_filter = Node::as_const(phase_filter_node)
+        .unwrap()
+        .tarval()
+        .get_long()
+        .to_string();
+    let node = call.args().nth(2).unwrap();
+
+    if phase.is_match(&phase_filter) {
+        assert!(
+            Node::is_const(node),
+            format!("expected {:?} to be a constant {}", node, phase)
+        );
+    }
+}
+
+fn assert_not_const(call: nodes::Call, phase: &Phase) {
+    let phase_filter_node = call.args().nth(1).unwrap();
+    // TODO: somehow suppport specifying optimizations by name instead of indices
+    let phase_filter = Node::as_const(phase_filter_node)
+        .unwrap()
+        .tarval()
+        .get_long()
+        .to_string();
+    let node = call.args().nth(2).unwrap();
+
+    if phase.is_match(&phase_filter) {
+        assert!(
+            !Node::is_const(node),
+            format!("expected {:?} to NOT be a constant {}", node, phase)
+        );
+    }
+}

--- a/optimization/src/compile_time_assertions.rs
+++ b/optimization/src/compile_time_assertions.rs
@@ -9,7 +9,11 @@ use libfirm_rs::{
 use std::fmt;
 
 /// Set this environment variable to enable these special functions
-pub const ENV_VAR: &'static str = "COMPRAKT_COMPILE_TIME_MJ_ASSERTS";
+pub const ENV_VAR_NAME: &'static str = "COMPRAKT_COMPILE_TIME_MJ_ASSERTS";
+
+lazy_static::lazy_static! {
+    static ref ENABLED: bool = std::env::var(ENV_VAR_NAME).is_ok();
+}
 
 #[derive(Default, Clone, Debug)]
 pub struct CompileTimeAssertions {}
@@ -57,7 +61,7 @@ impl CompileTimeAssertions {
     }
 
     fn disabled() -> bool {
-        !std::env::var(ENV_VAR).is_ok()
+        !(*ENABLED)
     }
 
     pub fn check_program(&self, program: &FirmProgram<'_, '_>, phase: Phase) {

--- a/optimization/src/constant_folding.rs
+++ b/optimization/src/constant_folding.rs
@@ -57,8 +57,9 @@ impl optimization::Local for ConstantFolding {
         constant_folding.run();
         let result = constant_folding.apply();
 
-        // TODO only do this in tests
-        check_asserts(graph);
+        if cfg!(test) {
+            check_asserts(graph);
+        }
 
         result
     }

--- a/optimization/src/lib.rs
+++ b/optimization/src/lib.rs
@@ -28,7 +28,7 @@ mod control_flow;
 use self::control_flow::ControlFlow;
 mod remove_critical_edges;
 pub use self::remove_critical_edges::RemoveCriticalEdges;
-mod compile_time_assertions;
+pub mod compile_time_assertions;
 mod lattices;
 pub use self::compile_time_assertions::{CompileTimeAssertions, Phase};
 

--- a/optimization/src/lib.rs
+++ b/optimization/src/lib.rs
@@ -28,7 +28,9 @@ mod control_flow;
 use self::control_flow::ControlFlow;
 mod remove_critical_edges;
 pub use self::remove_critical_edges::RemoveCriticalEdges;
+mod compile_time_assertions;
 mod lattices;
+pub use self::compile_time_assertions::{CompileTimeAssertions, Phase};
 
 /// An optimization that optimizes the whole program by examining all function
 /// graphs at once.
@@ -209,12 +211,29 @@ impl Level {
     pub fn run_all(&self, program: &mut FirmProgram<'_, '_>) {
         breakpoint!("before optimization sequence".to_string(), program);
         let measurement_all = Measurement::start("optimization phase");
+        let compile_time_assertions = CompileTimeAssertions::new();
 
         for (i, optimization) in self.sequence().iter().enumerate() {
             log::info!("Running optimization #{}: {:?}", i, optimization);
+            compile_time_assertions.check_program(
+                program,
+                Phase {
+                    opt_idx: i,
+                    opt_kind: optimization.kind,
+                    is_already_applied: false,
+                },
+            );
             let measurement = Measurement::start(&format!("opt #{}: {}", i, optimization.kind));
             optimization.run(program);
             measurement.stop();
+            compile_time_assertions.check_program(
+                program,
+                Phase {
+                    opt_idx: i,
+                    opt_kind: optimization.kind,
+                    is_already_applied: true,
+                },
+            );
             log::debug!("Finished optimization #{}: {:?}", i, optimization.kind);
         }
 

--- a/runner-integration-tests/src/lib.rs
+++ b/runner-integration-tests/src/lib.rs
@@ -132,7 +132,7 @@ pub fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command
                 });
 
             cmd.env("TERM", "dumb"); // disable color output
-            cmd.env(compile_time_assertions::ENV_VAR, "enabled");
+            cmd.env(compile_time_assertions::ENV_VAR_NAME, "enabled");
 
             cmd.args(compiler_args(phase));
             cmd.arg(filepath.as_os_str());

--- a/runner-integration-tests/src/lib.rs
+++ b/runner-integration-tests/src/lib.rs
@@ -7,7 +7,7 @@ pub mod yaml;
 pub use self::{lookup::*, testkind::*};
 use difference::Changeset;
 use failure::Fail;
-use optimization::Level;
+use optimization::{compile_time_assertions, Level};
 use serde::de::DeserializeOwned;
 use serde_derive::Deserialize;
 use std::{
@@ -132,6 +132,7 @@ pub fn compiler_call(compiler_call: CompilerCall, filepath: &PathBuf) -> Command
                 });
 
             cmd.env("TERM", "dumb"); // disable color output
+            cmd.env(compile_time_assertions::ENV_VAR, "enabled");
 
             cmd.args(compiler_args(phase));
             cmd.arg(filepath.as_os_str());


### PR DESCRIPTION
- only run custom assert logic in integration tests (or if the env var `COMPRAKT_COMPILE_TIME_MJ_ASSERTS` is set)
- abstract custom assert logic introduced by henning, can be applied to any optimization now

Example:
```java
---
optimizations: [ConstantFolding]
expect: change
        
stdout:
    is: "9\n"
---

class ConstantFoldingAfter {
    public void is_const(int expr) {}
}

class ConstantFoldingBefore {
    public void is_not_const(int expr) {}
}

class Opt1After {
    public void is_const(int expr) {}
    public void is_not_const(int expr) {}
}

class CF_Sub {
  public static void main(String[] args) {
    ConstantFoldingAfter expect_after = new ConstantFoldingAfter();
    ConstantFoldingBefore expect_before = new ConstantFoldingBefore();

    int a = 14 - 5;

    expect_before.is_not_const(a);
    expect_after.is_const(a);
    /* should not be evaluated since the class name is a mismatch */
    (new Opt1After()).is_const(a);
    (new Opt1After()).is_not_const(a);

    System.out.println(a);
  }
}
```